### PR TITLE
initial work for basisu

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "mgcb-basisu"
       ],
       "rollForward": false
+    },
+    "mgcb-crunch": {
+      "version": "1.16.4.1",
+      "commands": [
+        "mgcb-crunch"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "mgcb-crunch": {
-      "version": "1.16.4.1",
+      "version": "1.0.4.2",
       "commands": [
         "mgcb-crunch"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "mgcb-basisu": {
+      "version": "1.16.4.2",
+      "commands": [
+        "mgcb-basisu"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineManager.cs
@@ -666,6 +666,8 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 try
                 {
                     var importContext = new PipelineImporterContext(this);
+
+                    using var _ = ContextScopeFactory.BeginContext(importContext, pipelineEvent);
                     importedObject = importer.Import(pipelineEvent.SourceFile, importContext);
                 }
                 catch (PipelineException)
@@ -684,6 +686,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             else
             {
                 var importContext = new PipelineImporterContext(this);
+                using var _ = ContextScopeFactory.BeginContext(importContext, pipelineEvent);
                 importedObject = importer.Import(pipelineEvent.SourceFile, importContext);
             }
 
@@ -714,6 +717,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
                 try
                 {
                     var processContext = new PipelineProcessorContext(this, pipelineEvent);
+                    using var _ = ContextScopeFactory.BeginContext(processContext);
                     processedObject = processor.Process(importedObject, processContext);
                 }
                 catch (PipelineException)
@@ -732,6 +736,7 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
             else
             {
                 var processContext = new PipelineProcessorContext(this, pipelineEvent);
+                using var _ = ContextScopeFactory.BeginContext(processContext);
                 processedObject = processor.Process(importedObject, processContext);
             }
 

--- a/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
+++ b/MonoGame.Framework.Content.Pipeline/Builder/PipelineProcessorContext.cs
@@ -52,8 +52,9 @@ namespace MonoGame.Framework.Content.Pipeline.Builder
         {
             var processor = _manager.CreateProcessor(processorName, processorParameters);
             var processContext = new PipelineProcessorContext(_manager, new PipelineBuildEvent { Parameters = processorParameters } );
+            using var _ = ContextScopeFactory.BeginContext(processContext);
             var processedObject = processor.Process(input, processContext);
-           
+
             // Add its dependencies and built assets to ours.
             _pipelineEvent.Dependencies.AddRangeUnique(processContext._pipelineEvent.Dependencies);
             _pipelineEvent.BuildAsset.AddRangeUnique(processContext._pipelineEvent.BuildAsset);

--- a/MonoGame.Framework.Content.Pipeline/ContextScopeFactory.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContextScopeFactory.cs
@@ -177,7 +177,7 @@ namespace MonoGame.Framework.Content
             public override ContentBuildLogger Logger => _context.Logger;
             public override ContentIdentity SourceIdentity => _context.SourceIdentity;
         }
-        
+
         private class ContentImporterContextAdapter : ContextScope
         {
             private readonly ContentImporterContext _context;

--- a/MonoGame.Framework.Content.Pipeline/ContextScopeFactory.cs
+++ b/MonoGame.Framework.Content.Pipeline/ContextScopeFactory.cs
@@ -1,0 +1,196 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework.Content.Pipeline;
+using MonoGame.Framework.Content.Pipeline.Builder;
+
+namespace MonoGame.Framework.Content
+{
+
+    /// <summary>
+    /// The <see cref="IContentContext"/> represents some sort of context operation's context.
+    /// Usually, this represents a <see cref="ContentImporterContext"/>
+    /// or <see cref="ContentProcessorContext"/>.
+    ///
+    /// However, because those types are part of the XNA namespace, they cannot be modified directly.
+    /// This interface is an adapter over those types.
+    /// </summary>
+    public interface IContentContext : IDisposable
+    {
+        /// <inheritdoc cref="ContentImporterContext.IntermediateDirectory"/>
+        public string IntermediateDirectory { get; }
+
+        /// <inheritdoc cref="ContentImporterContext.Logger"/>
+        public ContentBuildLogger Logger { get; }
+
+        /// <inheritdoc cref="ContentProcessorContext.SourceIdentity"/>
+        public ContentIdentity SourceIdentity { get; }
+    }
+
+    /// <summary>
+    /// <para>
+    /// The <see cref="ContextScopeFactory"/> facilitates access to a <see cref="IContentContext"/>
+    /// instance without direct access to the actual context.
+    /// </para>
+    ///
+    /// <para>
+    /// Anytime a content context operation is about to start, the operation should signal
+    /// the <see cref="BeginContext(IContentContext)"/> method.
+    /// <b> Critically </b>, the content operation must <b>dispose</b> the resulting context
+    /// when the operation has concluded.
+    /// </para>
+    ///
+    /// <para>
+    /// The most recent content operation can be retrieved with the <see cref="ActiveContext"/>
+    /// property.
+    /// </para>
+    ///
+    /// </summary>
+    public static class ContextScopeFactory
+    {
+        private static List<IContentContext> _contextStack = new List<IContentContext>(1);
+        private static IContentContext _activeContext;
+
+        /// <summary>
+        /// Returns true when the <see cref="ActiveContext"/> is a valid <see cref="IContentContext"/> instance.
+        /// </summary>
+        public static bool HasActiveContext => _activeContext != null;
+
+        /// <summary>
+        /// Access the latest <see cref="IContentContext"/> operation.
+        /// If no operations are running (and therefor there is no context), this
+        /// accessor will throw a <see cref="PipelineException"/>.
+        ///
+        /// Use the <see cref="HasActiveContext"/> to check if there is an active context.
+        /// </summary>
+        /// <exception cref="PipelineException"></exception>
+        public static IContentContext ActiveContext
+        {
+            get
+            {
+                if (!HasActiveContext)
+                {
+                    throw new PipelineException(
+                        $"Cannot access {nameof(ActiveContext)} because there is no active context. Make sure that {nameof(ContextScopeFactory)}.{nameof(BeginContext)} has been called with the `using` keyword");
+                }
+
+                return _activeContext;
+            }
+        }
+
+        /// <summary>
+        /// Start a <see cref="ContentProcessorContext"/> operation.
+        /// The <see cref="ContentProcessorContext"/> instance will be adapted into a
+        /// <see cref="IContentContext"/>
+        ///
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>
+        /// <b>this return value must be disposed when the context operation is complete!</b>
+        /// </returns>
+        public static IContentContext BeginContext(ContentProcessorContext context)
+        {
+            return BeginContext(new ContentProcessorContextAdapter(context));
+        }
+
+
+        /// <summary>
+        /// Start a <see cref="ContentImporterContext"/> operation.
+        /// The <see cref="ContentImporterContext"/> instance will be adapted into a
+        /// <see cref="IContentContext"/>
+        ///
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="evt">
+        /// A <see cref="ContentImporterContext"/> does not include a source file,
+        /// but the originating <see cref="PipelineBuildEvent"/> <i>does</i>. The event
+        /// will be used to fulfill the <see cref="IContentContext.SourceIdentity"/> value.
+        /// </param>
+        /// <returns>
+        /// <b>this return value must be disposed when the context operation is complete!</b>
+        /// </returns>
+        public static IContentContext BeginContext(ContentImporterContext context, PipelineBuildEvent evt)
+        {
+            return BeginContext(new ContentImporterContextAdapter(context, evt));
+        }
+
+        /// <summary>
+        /// Start a content context operation.
+        /// </summary>
+        /// <param name="scope"></param>
+        /// <returns>
+        /// <b>this return value must be disposed when the context operation is complete!</b>
+        /// </returns>
+        public static IContentContext BeginContext(IContentContext scope)
+        {
+            _contextStack.Add(scope);
+            _activeContext = scope;
+            return scope;
+        }
+
+        /// <summary>
+        /// The default implementation of the <see cref="IContentContext"/>
+        /// provides a basic Dispose() method that will remove the context
+        /// from the history in the <see cref="ContextScopeFactory"/>
+        /// </summary>
+        public abstract class ContextScope : IContentContext
+        {
+            public abstract string IntermediateDirectory { get; }
+            public abstract ContentBuildLogger Logger { get; }
+            public abstract ContentIdentity SourceIdentity { get; }
+
+            /// <summary>
+            /// Remove this context operation from the history in the <see cref="ContextScopeFactory"/>.
+            /// If this context was the <see cref="ContextScopeFactory.ActiveContext"/>, then this
+            /// method will reset the <see cref="ContextScopeFactory.ActiveContext"/> value to the next
+            /// most-recent context operation, or null if none exist.
+            /// </summary>
+            public virtual void Dispose()
+            {
+                _contextStack.Remove(this);
+
+                // if someone else has already claimed the activeContext, then we don't need to care.
+                if (_activeContext != this) return;
+
+                // either use the "most recent" (aka, last) context, or if the list is empty,
+                //  there is no context.
+                _activeContext = _contextStack.Count > 0
+                    ? _contextStack[^1]
+                    : null;
+            }
+
+        }
+
+        private class ContentProcessorContextAdapter : ContextScope
+        {
+            private readonly ContentProcessorContext _context;
+
+            public ContentProcessorContextAdapter(ContentProcessorContext context)
+            {
+                _context = context;
+            }
+
+            public override string IntermediateDirectory => _context.IntermediateDirectory;
+            public override ContentBuildLogger Logger => _context.Logger;
+            public override ContentIdentity SourceIdentity => _context.SourceIdentity;
+        }
+        
+        private class ContentImporterContextAdapter : ContextScope
+        {
+            private readonly ContentImporterContext _context;
+
+            public ContentImporterContextAdapter(ContentImporterContext context, PipelineBuildEvent evt)
+            {
+                _context = context;
+                SourceIdentity = new ContentIdentity(sourceFilename: evt.SourceFile);
+            }
+
+            public override string IntermediateDirectory => _context.IntermediateDirectory;
+            public override ContentBuildLogger Logger => _context.Logger;
+            public override ContentIdentity SourceIdentity { get; }
+        }
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             return result;
         }
 
-        public static int Run(string command, string arguments, out string stdout, out string stderr, string stdin = null)
+        public static int Run(string command, string arguments, out string stdout, out string stderr, string stdin = null, string workingDirectory=null)
         {
             // This particular case is likely to be the most common and thus
             // warrants its own specific error message rather than falling
@@ -55,6 +55,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 RedirectStandardError = true,
                 RedirectStandardInput = true,
             };
+
+            if (!string.IsNullOrEmpty(workingDirectory))
+            {
+                processInfo.WorkingDirectory = workingDirectory;
+            }
 
             EnsureExecutable(fullPath);
 
@@ -157,12 +162,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             return null;
         }
 
-        /// <summary>   
-        /// Ensures the specified executable has the executable bit set.  If the    
-        /// executable doesn't have the executable bit set on Linux or Mac OS, then 
-        /// Mono will refuse to execute it. 
-        /// </summary>  
-        /// <param name="path">The full path to the executable.</param> 
+        /// <summary>
+        /// Ensures the specified executable has the executable bit set.  If the
+        /// executable doesn't have the executable bit set on Linux or Mac OS, then
+        /// Mono will refuse to execute it.
+        /// </summary>
+        /// <param name="path">The full path to the executable.</param>
         private static void EnsureExecutable(string path)
         {
             if (!path.StartsWith("/home") && !path.StartsWith("/Users"))
@@ -175,8 +180,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             }
             catch
             {
-                // This platform may not have chmod in the path, in which case we can't 
-                // do anything reasonable here. 
+                // This platform may not have chmod in the path, in which case we can't
+                // do anything reasonable here.
             }
         }
 
@@ -191,7 +196,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 File.Delete(filePath);
             }
             catch (Exception)
-            {                    
+            {
             }
         }
     }

--- a/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
+++ b/MonoGame.Framework.Content.Pipeline/ExternalTool.cs
@@ -27,6 +27,15 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
             return result;
         }
 
+        /// <summary>
+        /// Run a dotnet tool. The tool should be installed in a .config/dotnet-tools.json file somewhere in the project lineage.
+        /// </summary>
+        public static int RunDotnetTool(string toolName, string args, out string stdOut, out string stdErr, string stdIn=null, string workingDirectory=null)
+        {
+            var finalizedArgs = toolName + " " + args;
+            return ExternalTool.Run("dotnet", finalizedArgs, out stdOut, out stdErr, stdIn, workingDirectory);
+        }
+
         public static int Run(string command, string arguments, out string stdout, out string stderr, string stdin = null, string workingDirectory=null)
         {
             // This particular case is likely to be the most common and thus

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AstcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AstcBitmapContent.cs
@@ -1,4 +1,4 @@
-﻿// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
@@ -8,19 +8,11 @@ using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
-    public abstract class AtcBitmapContent : BitmapContent
+
+    public class AstcBitmapContent : BitmapContent
     {
+        private SurfaceFormat FORMAT => throw new NotImplementedException("astc is not a valid surface format yet");
         internal byte[] _bitmapData;
-
-        public AtcBitmapContent()
-            : base()
-        {
-        }
-
-        public AtcBitmapContent(int width, int height)
-            : base(width, height)
-        {
-        }
 
         public override byte[] GetPixelData()
         {
@@ -32,7 +24,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             _bitmapData = sourceData;
         }
 
-		protected override bool TryCopyFrom(BitmapContent sourceBitmap, Rectangle sourceRegion, Rectangle destinationRegion)
+        protected override bool TryCopyFrom(BitmapContent sourceBitmap, Rectangle sourceRegion,
+            Rectangle destinationRegion)
         {
             SurfaceFormat sourceFormat;
             if (!sourceBitmap.TryGetFormat(out sourceFormat))
@@ -42,7 +35,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             TryGetFormat(out format);
 
             // A shortcut for copying the entire bitmap to another bitmap of the same type and format
-            if (format == sourceFormat && (sourceRegion == new Rectangle(0, 0, Width, Height)) && sourceRegion == destinationRegion)
+            if (format == sourceFormat && (sourceRegion == new Rectangle(0, 0, Width, Height)) &&
+                sourceRegion == destinationRegion)
             {
                 SetPixelData(sourceBitmap.GetPixelData());
                 return true;
@@ -53,7 +47,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 return false;
 
             // If the source is not Vector4 or requires resizing, send it through BitmapContent.Copy
-            if (!(sourceBitmap is PixelBitmapContent<Vector4>) || sourceRegion.Width != destinationRegion.Width || sourceRegion.Height != destinationRegion.Height)
+            if (!(sourceBitmap is PixelBitmapContent<Vector4>) || sourceRegion.Width != destinationRegion.Width ||
+                sourceRegion.Height != destinationRegion.Height)
             {
                 try
                 {
@@ -66,17 +61,17 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-            // rg, basisU isn't printing an output path for ATC textures.
             BasisU.EncodeBytes(
                 sourceBitmap: sourceBitmap,
                 format: format,
                 out var compressedBytes);
             SetPixelData(compressedBytes);
 
-			return true;
+            return true;
         }
 
-        protected override bool TryCopyTo(BitmapContent destinationBitmap, Rectangle sourceRegion, Rectangle destinationRegion)
+        protected override bool TryCopyTo(BitmapContent destinationBitmap, Rectangle sourceRegion,
+            Rectangle destinationRegion)
         {
             SurfaceFormat destinationFormat;
             if (!destinationBitmap.TryGetFormat(out destinationFormat))
@@ -86,14 +81,21 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             TryGetFormat(out format);
 
             // A shortcut for copying the entire bitmap to another bitmap of the same type and format
-            if (format == destinationFormat && (sourceRegion == new Rectangle(0, 0, Width, Height)) && sourceRegion == destinationRegion)
+            if (format == destinationFormat && (sourceRegion == new Rectangle(0, 0, Width, Height)) &&
+                sourceRegion == destinationRegion)
             {
                 destinationBitmap.SetPixelData(GetPixelData());
                 return true;
             }
 
-            // No other support for copying from a ATC texture yet
+            // No other support for copying from a ASTC texture yet
             return false;
+        }
+
+        public override bool TryGetFormat(out SurfaceFormat format)
+        {
+            format = FORMAT;
+            return true;
         }
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AstcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AstcBitmapContent.cs
@@ -11,8 +11,26 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
     public class AstcBitmapContent : BitmapContent
     {
-        private SurfaceFormat FORMAT => throw new NotImplementedException("astc is not a valid surface format yet");
+        private SurfaceFormat FORMAT => SurfaceFormat.ASTC_4x4_Rgba;
         internal byte[] _bitmapData;
+
+        /// <summary>
+        /// Initializes a new instance of AstcBitmapContent.
+        /// </summary>
+        protected AstcBitmapContent()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of AstcBitmapContent with the specified width or height.
+        /// </summary>
+        /// <param name="width">Width in pixels of the bitmap resource.</param>
+        /// <param name="height">Height in pixels of the bitmap resource.</param>
+        public AstcBitmapContent(int width, int height)
+            : base(width, height)
+        {
+        }
 
         public override byte[] GetPixelData()
         {
@@ -63,7 +81,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             BasisU.EncodeBytes(
                 sourceBitmap: sourceBitmap,
-                format: format,
+                destinationFormat: format,
                 out var compressedBytes);
             SetPixelData(compressedBytes);
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
@@ -4,7 +4,7 @@
 
 using System;
 using Microsoft.Xna.Framework.Graphics;
-using ATI.TextureConverter;
+using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
@@ -67,26 +67,39 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
 
             // Convert to full colour 32-bit format. Floating point would be preferred for processing, but it appears the ATICompressor does not support this
-            var colorBitmap = new PixelBitmapContent<Color>(sourceRegion.Width, sourceRegion.Height);
-            BitmapContent.Copy(sourceBitmap, sourceRegion, colorBitmap, new Rectangle(0, 0, colorBitmap.Width, colorBitmap.Height));
-            sourceBitmap = colorBitmap;
+            // var colorBitmap = new PixelBitmapContent<Color>(sourceRegion.Width, sourceRegion.Height);
+            // BitmapContent.Copy(sourceBitmap, sourceRegion, colorBitmap, new Rectangle(0, 0, colorBitmap.Width, colorBitmap.Height));
+            // sourceBitmap = colorBitmap;
 
-			ATICompressor.CompressionFormat targetFormat;
-			switch (format)
+            var sourceData = sourceBitmap.GetPixelData();
+            if (!BasisU.TryEncodeBytes(
+                    sourceBitmap: this,
+                    width: Width,
+                    height: Height,
+                    hasAlpha: true,
+                    isLinearColor: true,
+                    format: format,
+                    out var compressedBytes))
             {
-				case SurfaceFormat.RgbaAtcExplicitAlpha:
-					targetFormat = ATICompressor.CompressionFormat.AtcRgbaExplicitAlpha;
-					break;
-				case SurfaceFormat.RgbaAtcInterpolatedAlpha:
-					targetFormat = ATICompressor.CompressionFormat.AtcRgbaInterpolatedAlpha;
-					break;
-				default:
-					return false;
-			}
-
-			var sourceData = sourceBitmap.GetPixelData();
-			var compressedData = ATICompressor.Compress(sourceData, Width, Height, targetFormat);
-			SetPixelData(compressedData);
+                return false;
+            }
+            SetPixelData(compressedBytes);
+			// ATICompressor.CompressionFormat targetFormat;
+			// switch (format)
+   //          {
+			// 	case SurfaceFormat.RgbaAtcExplicitAlpha:
+			// 		targetFormat = ATICompressor.CompressionFormat.AtcRgbaExplicitAlpha;
+			// 		break;
+			// 	case SurfaceFormat.RgbaAtcInterpolatedAlpha:
+			// 		targetFormat = ATICompressor.CompressionFormat.AtcRgbaInterpolatedAlpha;
+			// 		break;
+			// 	default:
+			// 		return false;
+			// }
+   //
+			// var sourceData = sourceBitmap.GetPixelData();
+			// var compressedData = ATICompressor.Compress(sourceData, Width, Height, targetFormat);
+			// SetPixelData(compressedData);
 
 			return true;
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             // rg, basisU isn't printing an output path for ATC textures.
             BasisU.EncodeBytes(
                 sourceBitmap: sourceBitmap,
-                format: format,
+                destinationFormat: format,
                 out var compressedBytes);
             SetPixelData(compressedBytes);
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-            // rg, basisU isn't printing an output path for ATC textures.
             BasisU.EncodeBytes(
                 sourceBitmap: sourceBitmap,
                 destinationFormat: format,

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
@@ -71,9 +71,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             // BitmapContent.Copy(sourceBitmap, sourceRegion, colorBitmap, new Rectangle(0, 0, colorBitmap.Width, colorBitmap.Height));
             // sourceBitmap = colorBitmap;
 
-            var sourceData = sourceBitmap.GetPixelData();
+            // rg, basisU isn't printing an output path for ATC textures.
             if (!BasisU.TryEncodeBytes(
-                    sourceBitmap: this,
+                    sourceBitmap: sourceBitmap,
                     width: Width,
                     height: Height,
                     hasAlpha: true,

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {

--- a/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/AtcBitmapContent.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using BCnEncoder.Shared;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 
@@ -66,10 +67,23 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-            BasisU.EncodeBytes(
+            CompressionFormat compressionFormat;
+            switch (format)
+            {
+                case SurfaceFormat.RgbaAtcExplicitAlpha:
+                    compressionFormat = CompressionFormat.AtcExplicitAlpha;
+                    break;
+                case SurfaceFormat.RgbaAtcInterpolatedAlpha:
+                    compressionFormat = CompressionFormat.AtcInterpolatedAlpha;
+                    break;
+                default:
+                    throw new PipelineException();
+            }
+            BcnUtil.Encode(
                 sourceBitmap: sourceBitmap,
-                destinationFormat: format,
+                destinationFormat: compressionFormat,
                 out var compressedBytes);
+
             SetPixelData(compressedBytes);
 
 			return true;

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 case TextureProcessorOutputFormat.DxtCompressed:
                 case TextureProcessorOutputFormat.Etc1Compressed:
                 case TextureProcessorOutputFormat.PvrCompressed:
+                case TextureProcessorOutputFormat.AstcCompressed:
                     return true;
             }
             return false;
@@ -117,6 +118,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             {
                 case TextureProcessorOutputFormat.AtcCompressed:
                     GraphicsUtil.CompressAti(context, content, isSpriteFont);
+                    break;
+
+                case TextureProcessorOutputFormat.AstcCompressed:
+                    GraphicsUtil.CompressAstc(context, content, isSpriteFont);
                     break;
 
                 case TextureProcessorOutputFormat.Color16Bit:

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DefaultTextureProfile.cs
@@ -27,9 +27,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         {
             switch (format)
             {
+#pragma warning disable CS0618 // Type or member is obsolete
+                case TextureProcessorOutputFormat.Etc1Compressed:
+#pragma warning restore CS0618 // Type or member is obsolete
+
                 case TextureProcessorOutputFormat.AtcCompressed:
                 case TextureProcessorOutputFormat.DxtCompressed:
-                case TextureProcessorOutputFormat.Etc1Compressed:
+                case TextureProcessorOutputFormat.EtcCompressed:
                 case TextureProcessorOutputFormat.PvrCompressed:
                 case TextureProcessorOutputFormat.AstcCompressed:
                     return true;
@@ -45,7 +49,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 if (platform == TargetPlatform.iOS)
                     format = TextureProcessorOutputFormat.PvrCompressed;
                 else if (platform == TargetPlatform.Android)
-                    format = TextureProcessorOutputFormat.Etc1Compressed;
+                    format = TextureProcessorOutputFormat.EtcCompressed;
                 else
                     format = TextureProcessorOutputFormat.DxtCompressed;
             }
@@ -88,8 +92,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     requiresPowerOfTwo = context.TargetProfile == GraphicsProfile.Reach;
                     break;
 
-                case TextureProcessorOutputFormat.PvrCompressed:
+#pragma warning disable CS0618 // Type or member is obsolete
                 case TextureProcessorOutputFormat.Etc1Compressed:
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                case TextureProcessorOutputFormat.PvrCompressed:
+                case TextureProcessorOutputFormat.EtcCompressed:
                     requiresPowerOfTwo = true;
                     break;
             }
@@ -132,8 +140,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     GraphicsUtil.CompressDxt(context, content, isSpriteFont);
                     break;
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 case TextureProcessorOutputFormat.Etc1Compressed:
+#pragma warning restore CS0618 // Type or member is obsolete
                     GraphicsUtil.CompressEtc1(context, content, isSpriteFont);
+                    break;
+
+                case TextureProcessorOutputFormat.EtcCompressed:
+                    GraphicsUtil.CompressEtc(context, content, isSpriteFont);
                     break;
 
                 case TextureProcessorOutputFormat.PvrCompressed:

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
@@ -56,26 +56,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
         }
 
-        [Obsolete]
-        private static void PrepareNVTT_DXT1(byte[] data, out bool hasTransparency)
-        {
-            hasTransparency = false;
-
-            for (var x = 0; x < data.Length; x += 4)
-            {
-                // NVTT wants BGRA where our source is RGBA so
-                // we swap the red and blue channels.
-                data[x] ^= data[x + 2];
-                data[x + 2] ^= data[x];
-                data[x] ^= data[x + 2];
-
-                // Look for non-opaque pixels.
-                var alpha = data[x + 3];
-                if (alpha < 255)
-                    hasTransparency = true;
-            }
-        }
-
         protected override bool TryCopyFrom(BitmapContent sourceBitmap, Rectangle sourceRegion, Rectangle destinationRegion)
         {
             SurfaceFormat sourceFormat;

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
@@ -3,8 +3,14 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using System.IO;
+using BCnEncoder.Encoder;
+using BCnEncoder.Shared;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
@@ -104,20 +110,23 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 case SurfaceFormat.Dxt1 when hasTransparency:
                 case SurfaceFormat.Dxt1SRgb when hasTransparency:
                 case SurfaceFormat.Dxt1a:
-                    Crunch.EncodeBytes(
+                    BcnUtil.Encode(
                         sourceBitmap: sourceBitmap,
-                        crunchFormat: CrunchFormat.Dxt1A,
+                        destinationFormat: CompressionFormat.Bc1WithAlpha,
                         out compressedBytes);
                     break;
                 case SurfaceFormat.Dxt1:
                 case SurfaceFormat.Dxt1SRgb:
-                    Crunch.EncodeBytes(
+
+                    BcnUtil.Encode(
                         sourceBitmap: sourceBitmap,
-                        crunchFormat: CrunchFormat.Dxt1,
+                        destinationFormat: CompressionFormat.Bc1,
                         out compressedBytes);
                     break;
                 case SurfaceFormat.Dxt3SRgb:
                 case SurfaceFormat.Dxt3:
+                    // the bcnEncoder does not perform well enough encoding BC2/DXT3
+                    //  specifically, the alpha channel seems to be off. Maybe it has something to do with the premult?
                     Crunch.EncodeBytes(
                         sourceBitmap: sourceBitmap,
                         crunchFormat: CrunchFormat.Dxt3,
@@ -125,9 +134,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     break;
                 case SurfaceFormat.Dxt5:
                 case SurfaceFormat.Dxt5SRgb:
-                    Crunch.EncodeBytes(
+                    BcnUtil.Encode(
                         sourceBitmap: sourceBitmap,
-                        crunchFormat: CrunchFormat.Dxt5,
+                        destinationFormat: CompressionFormat.Bc3,
                         out compressedBytes);
                     break;
                 default:

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
@@ -3,10 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using Microsoft.Xna.Framework.Graphics;
-// using Nvidia.TextureTools;
-using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
     public abstract class DxtBitmapContent : BitmapContent
     {
         private byte[] _bitmapData;
-        // private int _blockSize;
-        // private SurfaceFormat _format;
+        private int _blockSize;
+        private SurfaceFormat _format;
 
         private int _nvttWriteOffset;
 
@@ -22,8 +22,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         {
             if (!((blockSize == 8) || (blockSize == 16)))
                 throw new ArgumentException("Invalid block size");
-            // _blockSize = blockSize;
-            // TryGetFormat(out _format);
+            _blockSize = blockSize;
+            TryGetFormat(out _format);
         }
 
         protected DxtBitmapContent(int blockSize, int width, int height)
@@ -41,39 +41,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
         public override void SetPixelData(byte[] sourceData)
         {
             _bitmapData = sourceData;
-        }
-
-        [Obsolete]
-        private void NvttBeginImage(int size, int width, int height, int depth, int face, int miplevel)
-        {
-            _bitmapData = new byte[size];
-            _nvttWriteOffset = 0;
-        }
-
-        [Obsolete]
-        private bool NvttWriteImage(IntPtr data, int length)
-        {
-            Marshal.Copy(data, _bitmapData, _nvttWriteOffset, length);
-            _nvttWriteOffset += length;
-            return true;
-        }
-
-        [Obsolete]
-        private void NvttEndImage()
-        {
-        }
-
-        [Obsolete]
-        private static void PrepareNVTT(byte[] data)
-        {
-            for (var x = 0; x < data.Length; x += 4)
-            {
-                // NVTT wants BGRA where our source is RGBA so
-                // we swap the red and blue channels.
-                data[x] ^= data[x + 2];
-                data[x + 2] ^= data[x];
-                data[x] ^= data[x + 2];
-            }
         }
 
         private static void HasAnyAlpha(byte[] data, out bool hasTransparency)
@@ -173,84 +140,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 return false;
             }
             SetPixelData(compressedBytes);
-
-            // NVTT wants 8bit data in BGRA format.
-            // var colorBitmap = new PixelBitmapContent<Color>(sourceBitmap.Width, sourceBitmap.Height);
-            // BitmapContent.Copy(sourceBitmap, colorBitmap);
-            // var sourceData = colorBitmap.GetPixelData();
-            // var dataHandle = GCHandle.Alloc(sourceData, GCHandleType.Pinned);
-            //
-            // AlphaMode alphaMode;
-            // Format outputFormat;
-            // var alphaDither = false;
-            // switch (format)
-            // {
-            //     case SurfaceFormat.Dxt1:
-            //     case SurfaceFormat.Dxt1SRgb:
-            //     {
-            //         bool hasTransparency;
-            // PrepareNVTT_DXT1(sourceData, out hasTransparency);
-            //         outputFormat = hasTransparency ? Format.DXT1a : Format.DXT1;
-            //         alphaMode = hasTransparency ? AlphaMode.Transparency : AlphaMode.None;
-            //         alphaDither = true;
-            //         break;
-            //     }
-            //     case SurfaceFormat.Dxt3:
-            //     case SurfaceFormat.Dxt3SRgb:
-            //     {
-            //         PrepareNVTT(sourceData);
-            //         outputFormat = Format.DXT3;
-            //         alphaMode = AlphaMode.Transparency;
-            //         break;
-            //     }
-            //     case SurfaceFormat.Dxt5:
-            //     case SurfaceFormat.Dxt5SRgb:
-            //     {
-            //         PrepareNVTT(sourceData);
-            //         outputFormat = Format.DXT5;
-            //         alphaMode = AlphaMode.Transparency;
-            //         break;
-            //     }
-            //     default:
-            //         throw new InvalidOperationException("Invalid DXT surface format!");
-            // }
-            //
-            // // Do all the calls to the NVTT wrapper within this handler
-            // // so we properly clean up if things blow up.
-            // try
-            // {
-            //     var dataPtr = dataHandle.AddrOfPinnedObject();
-            //
-            //     var inputOptions = new InputOptions();
-            //     inputOptions.SetTextureLayout(TextureType.Texture2D, colorBitmap.Width, colorBitmap.Height, 1);
-            //     inputOptions.SetMipmapData(dataPtr, colorBitmap.Width, colorBitmap.Height, 1, 0, 0);
-            //     inputOptions.SetMipmapGeneration(false);
-            //     inputOptions.SetGamma(1.0f, 1.0f);
-            //     inputOptions.SetAlphaMode(alphaMode);
-            //
-            //     var compressionOptions = new CompressionOptions();
-            //     compressionOptions.SetFormat(outputFormat);
-            //     compressionOptions.SetQuality(Quality.Normal);
-            //
-            //     // TODO: This isn't working which keeps us from getting the
-            //     // same alpha dither behavior on DXT1 as XNA.
-            //     //
-            //     // See https://github.com/MonoGame/MonoGame/issues/6259
-            //     //
-            //     //if (alphaDither)
-            //         //compressionOptions.SetQuantization(false, false, true);
-            //
-            //     var outputOptions = new OutputOptions();
-            //     outputOptions.SetOutputHeader(false);
-            //     outputOptions.SetOutputOptionsOutputHandler(NvttBeginImage, NvttWriteImage, NvttEndImage);
-            //
-            //     var dxtCompressor = new Compressor();
-            //     dxtCompressor.Compress(inputOptions, compressionOptions, outputOptions);
-            // }
-            // finally
-            // {
-            //     dataHandle.Free();
-            // }
 
             return true;
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
@@ -122,26 +122,36 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             switch (format)
             {
                 case SurfaceFormat.Dxt1 when hasTransparency:
-                    throw new NotSupportedException(
-                        "The Dxt1 texture has alpha, but Monogame does not support Dxt1a. Please use Dxt5. ");
+                case SurfaceFormat.Dxt1SRgb when hasTransparency:
                 case SurfaceFormat.Dxt1a:
-                    // Dxt1a is a variant of Dxt1 with 1 bit for alpha, often called "punch-through".
-                    //  neither basisU or sbt_dxt support dxt1a.
-                    //  I've found this article to be helpful understanding punch-through,
-                    //  https://www.reedbeta.com/blog/understanding-bcn-texture-compression-formats/#degeneracy-and-breaking-it
-                    throw new NotSupportedException(
-                        "Monogame no longer supports Dxt3 texture compression. Please use Dxt5.");
-                case SurfaceFormat.Dxt3SRgb:
-                case SurfaceFormat.Dxt3:
-                    // Dxt3 is often ignored by modern compression tools and is not supported by basisU.
-                    throw new NotSupportedException(
-                        "Monogame no longer supports Dxt3 texture compression. Please use Dxt5.");
-                default:
-                    BasisU.EncodeBytes(
+                    Crunch.EncodeBytes(
                         sourceBitmap: sourceBitmap,
-                        destinationFormat: format,
+                        crunchFormat: CrunchFormat.Dxt1A,
                         out compressedBytes);
                     break;
+                case SurfaceFormat.Dxt1:
+                case SurfaceFormat.Dxt1SRgb:
+                    Crunch.EncodeBytes(
+                        sourceBitmap: sourceBitmap,
+                        crunchFormat: CrunchFormat.Dxt1,
+                        out compressedBytes);
+                    break;
+                case SurfaceFormat.Dxt3SRgb:
+                case SurfaceFormat.Dxt3:
+                    Crunch.EncodeBytes(
+                        sourceBitmap: sourceBitmap,
+                        crunchFormat: CrunchFormat.Dxt3,
+                        out compressedBytes);
+                    break;
+                case SurfaceFormat.Dxt5:
+                case SurfaceFormat.Dxt5SRgb:
+                    Crunch.EncodeBytes(
+                        sourceBitmap: sourceBitmap,
+                        crunchFormat: CrunchFormat.Dxt5,
+                        out compressedBytes);
+                    break;
+                default:
+                    throw new PipelineException($"{nameof(DxtBitmapContent)} cannot compress format=[{format}]");
             }
 
             SetPixelData(compressedBytes);

--- a/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/DxtBitmapContent.cs
@@ -3,13 +3,9 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
-using System.IO;
-using BCnEncoder.Encoder;
 using BCnEncoder.Shared;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             if (!sourceBitmap.TryGetFormat(out sourceFormat))
                 return false;
 
+            SurfaceFormat format;
+            TryGetFormat(out format);
+
             // A shortcut for copying the entire bitmap to another bitmap of the same type and format
             if (SurfaceFormat.RgbEtc1 == sourceFormat && (sourceRegion == new Rectangle(0, 0, Width, Height)) && sourceRegion == destinationRegion)
             {
@@ -82,12 +85,12 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             }
 
             if (!BasisU.TryEncodeBytes(
-                    sourceBitmap: this,
+                    sourceBitmap: sourceBitmap,
                     width: Width,
                     height: Height,
                     hasAlpha: false,
                     isLinearColor: true, // TODO: support etc2
-                    format: sourceFormat,
+                    format: format,
                     out var compressedBytes))
             {
                 return false;

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             BasisU.EncodeBytes(
                 sourceBitmap: sourceBitmap,
-                format: format,
+                destinationFormat: format,
                 out var compressedBytes);
             SetPixelData(compressedBytes);
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
@@ -85,17 +85,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-            if (!BasisU.TryEncodeBytes(
-                    sourceBitmap: sourceBitmap,
-                    width: Width,
-                    height: Height,
-                    hasAlpha: false,
-                    isLinearColor: true, // TODO: support etc2
-                    format: format,
-                    out var compressedBytes))
-            {
-                return false;
-            }
+            BasisU.EncodeBytes(
+                sourceBitmap: sourceBitmap,
+                format: format,
+                out var compressedBytes);
             SetPixelData(compressedBytes);
 
             return true;

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
@@ -85,9 +85,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-            BasisU.EncodeBytes(
+            Crunch.EncodeBytes(
                 sourceBitmap: sourceBitmap,
-                destinationFormat: format,
+                crunchFormat: CrunchFormat.Etc1,
                 out var compressedBytes);
             SetPixelData(compressedBytes);
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
@@ -5,7 +5,6 @@
 using System;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc1BitmapContent.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc2BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc2BitmapContent.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             BasisU.EncodeBytes(
                 sourceBitmap: sourceBitmap,
-                format: format,
+                destinationFormat: format,
                 out var compressedBytes);
             SetPixelData(compressedBytes);
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc2BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc2BitmapContent.cs
@@ -5,7 +5,6 @@
 using System;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {

--- a/MonoGame.Framework.Content.Pipeline/Graphics/Etc2BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/Etc2BitmapContent.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-            BasisU.EncodeBytes(
+            Crunch.EncodeBytes(
                 sourceBitmap: sourceBitmap,
-                destinationFormat: format,
+                crunchFormat: CrunchFormat.Etc2A,
                 out var compressedBytes);
             SetPixelData(compressedBytes);
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -182,13 +182,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             if (isSpriteFont)
                 CompressFontDXT3(content);
             else if (alphaRange == AlphaRange.Opaque)
-
                 content.ConvertBitmapType(typeof(Dxt1BitmapContent));
             else if (alphaRange == AlphaRange.Cutout)
-                // BasisU does not support DXT1a, so to support alpha, we must use DXT5
-                content.ConvertBitmapType(typeof(Dxt5BitmapContent));
+                content.ConvertBitmapType(typeof(Dxt3BitmapContent));
             else
-                // full range alpha is best supported by DXT5
                 content.ConvertBitmapType(typeof(Dxt5BitmapContent));
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -182,9 +182,11 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             if (isSpriteFont)
                 CompressFontDXT3(content);
             else if (alphaRange == AlphaRange.Opaque)
+
                 content.ConvertBitmapType(typeof(Dxt1BitmapContent));
             else if (alphaRange == AlphaRange.Cutout)
-                content.ConvertBitmapType(typeof(Dxt3BitmapContent)); // TODO: this will need to change to Dxt5, I think
+                // BasisU does not support DXT1a, so to support alpha, we must use DXT5
+                content.ConvertBitmapType(typeof(Dxt5BitmapContent));
             else
                 content.ConvertBitmapType(typeof(Dxt5BitmapContent));
         }
@@ -198,13 +200,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 return;
             }
 
-            var face = content.Faces[0][0];
-			var alphaRange = CalculateAlphaRange(face);
-
-            if (alphaRange == AlphaRange.Full)
-                content.ConvertBitmapType(typeof(AtcExplicitBitmapContent));
-            else
-                content.ConvertBitmapType(typeof(AtcInterpolatedBitmapContent));
+            // basisU only supports ATC Interpolated, so the alphaRange is irrelevant.
+            content.ConvertBitmapType(typeof(AtcInterpolatedBitmapContent));
         }
 
         static public void CompressEtc1(ContentProcessorContext context, TextureContent content, bool isSpriteFont)

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             if (context.TargetProfile == GraphicsProfile.Reach)
             {
                 if (!IsPowerOfTwo(face.Width) || !IsPowerOfTwo(face.Height))
-                    throw new PipelineException("DXT compression requires width and height must be powers of two in Reach graphics profile.");                
+                    throw new PipelineException("DXT compression requires width and height must be powers of two in Reach graphics profile.");
             }
 
             // Test the alpha channel to figure out if we have alpha.
@@ -175,8 +175,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             // between DXT1 for cutouts and DXT5 for fractional alpha.
             //
             // DXT3 however can produce better results for high frequency
-            // alpha like a chain link fence where is DXT5 is better for 
-            // low frequency alpha like clouds.  I don't know how we can 
+            // alpha like a chain link fence where is DXT5 is better for
+            // low frequency alpha like clouds.  I don't know how we can
             // pick the right thing in this case without a hint.
             //
             if (isSpriteFont)
@@ -184,7 +184,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             else if (alphaRange == AlphaRange.Opaque)
                 content.ConvertBitmapType(typeof(Dxt1BitmapContent));
             else if (alphaRange == AlphaRange.Cutout)
-                content.ConvertBitmapType(typeof(Dxt3BitmapContent));
+                content.ConvertBitmapType(typeof(Dxt3BitmapContent)); // TODO: this will need to change to Dxt5, I think
             else
                 content.ConvertBitmapType(typeof(Dxt5BitmapContent));
         }

--- a/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/GraphicsUtil.cs
@@ -198,8 +198,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 return;
             }
 
-            // basisU only supports ATC Interpolated, so the alphaRange is irrelevant.
-            content.ConvertBitmapType(typeof(AtcInterpolatedBitmapContent));
+            var face = content.Faces[0][0];
+            var alphaRange = CalculateAlphaRange(face);
+
+            if (alphaRange == AlphaRange.Full)
+                content.ConvertBitmapType(typeof(AtcExplicitBitmapContent));
+            else
+                content.ConvertBitmapType(typeof(AtcInterpolatedBitmapContent));
         }
 
         static public void CompressAstc(ContentProcessorContext context, TextureContent content, bool isSpriteFont)

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
@@ -3,8 +3,8 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
-using PVRTexLibNET;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
@@ -88,41 +88,70 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-            PixelFormat targetFormat;
+
+            bool hasAlpha = false;
             switch (format)
             {
-                case SurfaceFormat.RgbPvrtc2Bpp:
-                    targetFormat = PixelFormat.PVRTCI_2bpp_RGB;
-                    break;
-                case SurfaceFormat.RgbaPvrtc2Bpp:
-                    targetFormat = PixelFormat.PVRTCI_2bpp_RGBA;
+                case SurfaceFormat.RgbaPvrtc4Bpp:
+                    hasAlpha = true;
                     break;
                 case SurfaceFormat.RgbPvrtc4Bpp:
-                    targetFormat = PixelFormat.PVRTCI_4bpp_RGB;
+                    hasAlpha = false;
                     break;
-                case SurfaceFormat.RgbaPvrtc4Bpp:
-                    targetFormat = PixelFormat.PVRTCI_4bpp_RGBA;
-                    break;
-                default:
-                    return false;
             }
 
-            // Create the texture object in the PVR library
             var sourceData = sourceBitmap.GetPixelData();
-            var rgba32F = (PixelFormat)0x2020202061626772; // static const PixelType PVRStandard32PixelType = PixelType('r', 'g', 'b', 'a', 32, 32, 32, 32);
-            using (var pvrTexture = PVRTexture.CreateTexture(sourceData, (uint)sourceBitmap.Width, (uint)sourceBitmap.Height, 1,
-                rgba32F, true, VariableType.Float, ColourSpace.lRGB))
+            if (!BasisU.TryEncodeBytes(
+                    sourceBitmap: this,
+                    width: Width,
+                    height: Height,
+                    hasAlpha: hasAlpha,
+                    isLinearColor: true,
+                    format: format,
+                    out var compressedBytes))
             {
-                // Resize the bitmap if needed
-                if ((sourceBitmap.Width != Width) || (sourceBitmap.Height != Height))
-                    pvrTexture.Resize((uint)Width, (uint)Height, 1, ResizeMode.Cubic);
-                // On Linux, anything less than CompressorQuality.PVRTCHigh crashes in libpthread.so at the end of compression
-                pvrTexture.Transcode(targetFormat, VariableType.UnsignedByte, ColourSpace.lRGB, CompressorQuality.PVRTCHigh);
-                var texDataSize = pvrTexture.GetTextureDataSize(0);
-                var texData = new byte[texDataSize];
-                pvrTexture.GetTextureData(texData, texDataSize);
-                SetPixelData(texData);
+                return false;
             }
+
+            SetPixelData(compressedBytes);
+
+            // now that there is an intermediate file, we can extract the data using
+
+            // PixelFormat targetFormat;
+            // switch (format)
+            // {
+            //     case SurfaceFormat.RgbPvrtc2Bpp:
+            //         targetFormat = PixelFormat.PVRTCI_2bpp_RGB;
+            //         break;
+            //     case SurfaceFormat.RgbaPvrtc2Bpp:
+            //         targetFormat = PixelFormat.PVRTCI_2bpp_RGBA;
+            //         break;
+            //     case SurfaceFormat.RgbPvrtc4Bpp:
+            //         targetFormat = PixelFormat.PVRTCI_4bpp_RGB;
+            //         break;
+            //     case SurfaceFormat.RgbaPvrtc4Bpp:
+            //         targetFormat = PixelFormat.PVRTCI_4bpp_RGBA;
+            //         break;
+            //     default:
+            //         return false;
+            // }
+            //
+            // // Create the texture object in the PVR library
+            // var sourceData = sourceBitmap.GetPixelData();
+            // var rgba32F = (PixelFormat)0x2020202061626772; // static const PixelType PVRStandard32PixelType = PixelType('r', 'g', 'b', 'a', 32, 32, 32, 32);
+            // using (var pvrTexture = PVRTexture.CreateTexture(sourceData, (uint)sourceBitmap.Width, (uint)sourceBitmap.Height, 1,
+            //     rgba32F, true, VariableType.Float, ColourSpace.lRGB))
+            // {
+            //     // Resize the bitmap if needed
+            //     if ((sourceBitmap.Width != Width) || (sourceBitmap.Height != Height))
+            //         pvrTexture.Resize((uint)Width, (uint)Height, 1, ResizeMode.Cubic);
+            //     // On Linux, anything less than CompressorQuality.PVRTCHigh crashes in libpthread.so at the end of compression
+            //     pvrTexture.Transcode(targetFormat, VariableType.UnsignedByte, ColourSpace.lRGB, CompressorQuality.PVRTCHigh);
+            //     var texDataSize = pvrTexture.GetTextureDataSize(0);
+            //     var texData = new byte[texDataSize];
+            //     pvrTexture.GetTextureData(texData, texDataSize);
+            //     SetPixelData(texData);
+            // }
             return true;
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             BasisU.EncodeBytes(
                 sourceBitmap: sourceBitmap,
-                format: format,
+                destinationFormat: format,
                 out var compressedBytes);
 
             SetPixelData(compressedBytes);

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
@@ -89,29 +89,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                 }
             }
 
-
-            bool hasAlpha = false;
-            switch (format)
-            {
-                case SurfaceFormat.RgbaPvrtc4Bpp:
-                    hasAlpha = true;
-                    break;
-                case SurfaceFormat.RgbPvrtc4Bpp:
-                    hasAlpha = false;
-                    break;
-            }
-
-            if (!BasisU.TryEncodeBytes(
-                    sourceBitmap: sourceBitmap,
-                    width: Width,
-                    height: Height,
-                    hasAlpha: hasAlpha,
-                    isLinearColor: true,
-                    format: format,
-                    out var compressedBytes))
-            {
-                return false;
-            }
+            BasisU.EncodeBytes(
+                sourceBitmap: sourceBitmap,
+                format: format,
+                out var compressedBytes);
 
             SetPixelData(compressedBytes);
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
@@ -5,7 +5,6 @@
 using System;
 using Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 using Microsoft.Xna.Framework.Graphics;
-using MonoGame.Framework.Utilities;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
@@ -96,43 +95,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 
             SetPixelData(compressedBytes);
 
-            // now that there is an intermediate file, we can extract the data using
-
-            // PixelFormat targetFormat;
-            // switch (format)
-            // {
-            //     case SurfaceFormat.RgbPvrtc2Bpp:
-            //         targetFormat = PixelFormat.PVRTCI_2bpp_RGB;
-            //         break;
-            //     case SurfaceFormat.RgbaPvrtc2Bpp:
-            //         targetFormat = PixelFormat.PVRTCI_2bpp_RGBA;
-            //         break;
-            //     case SurfaceFormat.RgbPvrtc4Bpp:
-            //         targetFormat = PixelFormat.PVRTCI_4bpp_RGB;
-            //         break;
-            //     case SurfaceFormat.RgbaPvrtc4Bpp:
-            //         targetFormat = PixelFormat.PVRTCI_4bpp_RGBA;
-            //         break;
-            //     default:
-            //         return false;
-            // }
-            //
-            // // Create the texture object in the PVR library
-            // var sourceData = sourceBitmap.GetPixelData();
-            // var rgba32F = (PixelFormat)0x2020202061626772; // static const PixelType PVRStandard32PixelType = PixelType('r', 'g', 'b', 'a', 32, 32, 32, 32);
-            // using (var pvrTexture = PVRTexture.CreateTexture(sourceData, (uint)sourceBitmap.Width, (uint)sourceBitmap.Height, 1,
-            //     rgba32F, true, VariableType.Float, ColourSpace.lRGB))
-            // {
-            //     // Resize the bitmap if needed
-            //     if ((sourceBitmap.Width != Width) || (sourceBitmap.Height != Height))
-            //         pvrTexture.Resize((uint)Width, (uint)Height, 1, ResizeMode.Cubic);
-            //     // On Linux, anything less than CompressorQuality.PVRTCHigh crashes in libpthread.so at the end of compression
-            //     pvrTexture.Transcode(targetFormat, VariableType.UnsignedByte, ColourSpace.lRGB, CompressorQuality.PVRTCHigh);
-            //     var texDataSize = pvrTexture.GetTextureDataSize(0);
-            //     var texData = new byte[texDataSize];
-            //     pvrTexture.GetTextureData(texData, texDataSize);
-            //     SetPixelData(texData);
-            // }
             return true;
         }
 

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcBitmapContent.cs
@@ -100,9 +100,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
                     break;
             }
 
-            var sourceData = sourceBitmap.GetPixelData();
             if (!BasisU.TryEncodeBytes(
-                    sourceBitmap: this,
+                    sourceBitmap: sourceBitmap,
                     width: Width,
                     height: Height,
                     hasAlpha: hasAlpha,

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcRgb2BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcRgb2BitmapContent.cs
@@ -2,10 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
+    [Obsolete("PVRTC 2BPP formats are no longer supported, and this will be removed in a future version.")]
     public class PvrtcRgb2BitmapContent : PvrtcBitmapContent
     {
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcRgba2BitmapContent.cs
+++ b/MonoGame.Framework.Content.Pipeline/Graphics/PvrtcRgba2BitmapContent.cs
@@ -2,10 +2,12 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
 {
+    [Obsolete("PVRTC 2BPP formats are no longer supported, and this will be removed in a future version.")]
     public class PvrtcRgba2BitmapContent : PvrtcBitmapContent
     {
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -108,11 +108,6 @@
       <PackagePath>runtimes\linux-x64\native\linux</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\ThirdParty\Dependencies\basisu\MacOS\basisu" Visible="false">
-      <Link>osx\basisu</Link>
-      <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="..\ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib" Visible="false">
       <Link>libFreeImage.dylib</Link>
       <PackagePath>runtimes\osx\native\libFreeImage.dylib</PackagePath>

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -86,50 +86,18 @@
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="SharpDX" Version="4.0.1" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
-    <PackageReference Include="QoiSharp" Version="1.0.0"/>
-
-      <Reference Include="KtxSharp">
-          <HintPath>..\ThirdParty\Dependencies\libktxsharp\netstandard2.0\KtxSharp.dll</HintPath>
-      </Reference>
-<!--      <Content Include="..\ThirdParty\Dependencies\libktxsharp\netstandard2.0\KtxSharp.dll" PackagePath="lib\net8.0" Visible="false">-->
-<!--          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--          -->
-<!--      </Content>-->
-      
+    <PackageReference Include="BrewedInk.LibKTX" Version="0.9.2" />
   </ItemGroup>
-    
+
   <ItemGroup Condition="'$(CopyContentFiles)' == 'True'">
     <Content Include="..\ThirdParty\Dependencies\CppNet\CppNet.dll" PackagePath="lib\net8.0" Visible="false" />
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Nvidia.TextureTools.dll" PackagePath="lib\net8.0" Visible="false" />-->
-      <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" PackagePath="lib\net8.0" Visible="false" />
-<!--    <Content Include="..\ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll" PackagePath="lib\net8.0" Visible="false" />-->
-<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" PackagePath="lib\net8.0" Visible="false" />-->
+    <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" PackagePath="lib\net8.0" Visible="false" />
 
     <Content Include="..\ThirdParty\Dependencies\FreeImage.NET\Linux\x64\libfreeimage-3.17.0.so" Visible="false">
       <Link>libFreeImage.so</Link>
       <PackagePath>runtimes\linux-x64\native\libFreeImage.so</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvcore.so" Visible="false">-->
-<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvimage.so" Visible="false">-->
-<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvmath.so" Visible="false">-->
-<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvtt.so" Visible="false">-->
-<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\Linux\x64\libPVRTexLibWrapper.so" Visible="false">-->
-<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
     <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\libfreetype.6.so" Visible="false">
       <Link>libfreetype6.so</Link>
       <PackagePath>runtimes\linux-x64\native\libfreetype6.so</PackagePath>
@@ -159,26 +127,6 @@
       <PackagePath>runtimes\osx\native\libFreeImage.dylib</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvcore.dylib" Visible="false">-->
-<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvimage.dylib" Visible="false">-->
-<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvmath.dylib" Visible="false">-->
-<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvtt.dylib" Visible="false">-->
-<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\OSX\x86\libPVRTexLibWrapper.dylib" Visible="false">-->
-<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
     <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\libfreetype.6.dylib" Visible="false">
       <Link>libfreetype6.dylib</Link>
       <PackagePath>runtimes\osx\native\libfreetype6.dylib</PackagePath>
@@ -215,14 +163,6 @@
       <PackagePath>runtimes\win-x64\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Windows\nvtt.dll" Visible="false">-->
-<!--      <PackagePath>runtimes\win-x64\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
-<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\Windows\x64\PVRTexLibWrapper.dll" Visible="false">-->
-<!--      <PackagePath>runtimes\win-x64\native</PackagePath>-->
-<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
-<!--    </Content>-->
     <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\freetype6.dll" Visible="false">
       <PackagePath>runtimes\win-x64\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -54,18 +54,9 @@
     <Reference Include="CppNet">
       <HintPath>..\ThirdParty\Dependencies\CppNet\CppNet.dll</HintPath>
     </Reference>
-<!--    <Reference Include="Nvidia.TextureTools">-->
-<!--      <HintPath>..\ThirdParty\Dependencies\NVTT\Nvidia.TextureTools.dll</HintPath>-->
-<!--    </Reference>-->
     <Reference Include="SharpFont">
       <HintPath>..\ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll</HintPath>
     </Reference>
-<!--    <Reference Include="ATI.TextureConverter">-->
-<!--      <HintPath>..\ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll</HintPath>-->
-<!--    </Reference>-->
-<!--    <Reference Include="PVRTexLibNET">-->
-<!--      <HintPath>..\ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll</HintPath>-->
-<!--    </Reference>-->
   </ItemGroup>
 
   <ItemGroup Condition="'$(SolutionName)' != 'MonoGame.Framework.WindowsDX'">
@@ -86,7 +77,7 @@
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="SharpDX" Version="4.0.1" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
-    <PackageReference Include="BrewedInk.LibKTX" Version="0.9.2" />
+    <PackageReference Include="LibKTX" Version="0.9.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(CopyContentFiles)' == 'True'">

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -54,18 +54,18 @@
     <Reference Include="CppNet">
       <HintPath>..\ThirdParty\Dependencies\CppNet\CppNet.dll</HintPath>
     </Reference>
-    <Reference Include="Nvidia.TextureTools">
-      <HintPath>..\ThirdParty\Dependencies\NVTT\Nvidia.TextureTools.dll</HintPath>
-    </Reference>
+<!--    <Reference Include="Nvidia.TextureTools">-->
+<!--      <HintPath>..\ThirdParty\Dependencies\NVTT\Nvidia.TextureTools.dll</HintPath>-->
+<!--    </Reference>-->
     <Reference Include="SharpFont">
       <HintPath>..\ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll</HintPath>
     </Reference>
-    <Reference Include="ATI.TextureConverter">
-      <HintPath>..\ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll</HintPath>
-    </Reference>
-    <Reference Include="PVRTexLibNET">
-      <HintPath>..\ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll</HintPath>
-    </Reference>
+<!--    <Reference Include="ATI.TextureConverter">-->
+<!--      <HintPath>..\ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll</HintPath>-->
+<!--    </Reference>-->
+<!--    <Reference Include="PVRTexLibNET">-->
+<!--      <HintPath>..\ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll</HintPath>-->
+<!--    </Reference>-->
   </ItemGroup>
 
   <ItemGroup Condition="'$(SolutionName)' != 'MonoGame.Framework.WindowsDX'">
@@ -86,40 +86,50 @@
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="SharpDX" Version="4.0.1" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />
-  </ItemGroup>
+    <PackageReference Include="QoiSharp" Version="1.0.0"/>
 
+      <Reference Include="KtxSharp">
+          <HintPath>..\ThirdParty\Dependencies\libktxsharp\netstandard2.0\KtxSharp.dll</HintPath>
+      </Reference>
+<!--      <Content Include="..\ThirdParty\Dependencies\libktxsharp\netstandard2.0\KtxSharp.dll" PackagePath="lib\net8.0" Visible="false">-->
+<!--          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--          -->
+<!--      </Content>-->
+      
+  </ItemGroup>
+    
   <ItemGroup Condition="'$(CopyContentFiles)' == 'True'">
     <Content Include="..\ThirdParty\Dependencies\CppNet\CppNet.dll" PackagePath="lib\net8.0" Visible="false" />
-    <Content Include="..\ThirdParty\Dependencies\NVTT\Nvidia.TextureTools.dll" PackagePath="lib\net8.0" Visible="false" />
-    <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" PackagePath="lib\net8.0" Visible="false" />
-    <Content Include="..\ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll" PackagePath="lib\net8.0" Visible="false" />
-    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" PackagePath="lib\net8.0" Visible="false" />
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Nvidia.TextureTools.dll" PackagePath="lib\net8.0" Visible="false" />-->
+      <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\SharpFont.dll" PackagePath="lib\net8.0" Visible="false" />
+<!--    <Content Include="..\ThirdParty\Dependencies\ATI.TextureConverter\ATI.TextureConverter.dll" PackagePath="lib\net8.0" Visible="false" />-->
+<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\PVRTexLibNET.dll" PackagePath="lib\net8.0" Visible="false" />-->
 
     <Content Include="..\ThirdParty\Dependencies\FreeImage.NET\Linux\x64\libfreeimage-3.17.0.so" Visible="false">
       <Link>libFreeImage.so</Link>
       <PackagePath>runtimes\linux-x64\native\libFreeImage.so</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvcore.so" Visible="false">
-      <PackagePath>runtimes\linux-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvimage.so" Visible="false">
-      <PackagePath>runtimes\linux-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvmath.so" Visible="false">
-      <PackagePath>runtimes\linux-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvtt.so" Visible="false">
-      <PackagePath>runtimes\linux-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\Linux\x64\libPVRTexLibWrapper.so" Visible="false">
-      <PackagePath>runtimes\linux-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvcore.so" Visible="false">-->
+<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvimage.so" Visible="false">-->
+<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvmath.so" Visible="false">-->
+<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Linux\libnvtt.so" Visible="false">-->
+<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\Linux\x64\libPVRTexLibWrapper.so" Visible="false">-->
+<!--      <PackagePath>runtimes\linux-x64\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
     <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\libfreetype.6.so" Visible="false">
       <Link>libfreetype6.so</Link>
       <PackagePath>runtimes\linux-x64\native\libfreetype6.so</PackagePath>
@@ -139,32 +149,36 @@
       <PackagePath>runtimes\linux-x64\native\linux</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-
+    <Content Include="..\ThirdParty\Dependencies\basisu\MacOS\basisu" Visible="false">
+      <Link>osx\basisu</Link>
+      <PackagePath>runtimes\osx\native</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="..\ThirdParty\Dependencies\FreeImage.NET\MacOS\libfreeimage.dylib" Visible="false">
       <Link>libFreeImage.dylib</Link>
       <PackagePath>runtimes\osx\native\libFreeImage.dylib</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvcore.dylib" Visible="false">
-      <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvimage.dylib" Visible="false">
-      <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvmath.dylib" Visible="false">
-      <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvtt.dylib" Visible="false">
-      <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\OSX\x86\libPVRTexLibWrapper.dylib" Visible="false">
-      <PackagePath>runtimes\osx\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvcore.dylib" Visible="false">-->
+<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvimage.dylib" Visible="false">-->
+<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvmath.dylib" Visible="false">-->
+<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\MacOS\libnvtt.dylib" Visible="false">-->
+<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\OSX\x86\libPVRTexLibWrapper.dylib" Visible="false">-->
+<!--      <PackagePath>runtimes\osx\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
     <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\libfreetype.6.dylib" Visible="false">
       <Link>libfreetype6.dylib</Link>
       <PackagePath>runtimes\osx\native\libfreetype6.dylib</PackagePath>
@@ -201,14 +215,14 @@
       <PackagePath>runtimes\win-x64\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="..\ThirdParty\Dependencies\NVTT\Windows\nvtt.dll" Visible="false">
-      <PackagePath>runtimes\win-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\Windows\x64\PVRTexLibWrapper.dll" Visible="false">
-      <PackagePath>runtimes\win-x64\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+<!--    <Content Include="..\ThirdParty\Dependencies\NVTT\Windows\nvtt.dll" Visible="false">-->
+<!--      <PackagePath>runtimes\win-x64\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
+<!--    <Content Include="..\ThirdParty\Dependencies\PVRTexLibNET\Windows\x64\PVRTexLibWrapper.dll" Visible="false">-->
+<!--      <PackagePath>runtimes\win-x64\native</PackagePath>-->
+<!--      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>-->
+<!--    </Content>-->
     <Content Include="..\ThirdParty\Dependencies\SharpFont\x64\freetype6.dll" Visible="false">
       <PackagePath>runtimes\win-x64\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
+++ b/MonoGame.Framework.Content.Pipeline/MonoGame.Framework.Content.Pipeline.csproj
@@ -74,6 +74,8 @@
 
   <ItemGroup>
     <PackageReference Include="AssimpNet" Version="4.1.0" />
+    <PackageReference Include="BCnEncoder.Net" Version="2.1.0" />
+    <PackageReference Include="BCnEncoder.Net.ImageSharp" Version="1.1.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="SharpDX" Version="4.0.1" />
     <PackageReference Include="SharpDX.D3DCompiler" Version="4.0.1" />

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessorOutputFormat.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessorOutputFormat.cs
@@ -51,5 +51,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         /// The input texture is compressed using ATI texture compression.  Used on some Android platforms.
         /// </summary>
         AtcCompressed,
+
+        /// <summary>
+        /// The input texture is compressed using Adaptive Scalable Texture Compression. Used on some Mobile and Intel platforms.
+        /// </summary>
+        AstcCompressed,
     }
 }

--- a/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessorOutputFormat.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/TextureProcessorOutputFormat.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+using System;
+
 namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
 {
     /// <summary>
@@ -40,6 +42,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         /// <summary>
         /// The input texture is compressed using ETC1 texture compression.  Used on Android platforms.
         /// </summary>
+        [Obsolete("Prefer " + nameof(EtcCompressed) + " when possible.")]
         Etc1Compressed,
 
         /// <summary>
@@ -51,6 +54,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         /// The input texture is compressed using ATI texture compression.  Used on some Android platforms.
         /// </summary>
         AtcCompressed,
+
+        /// <summary>
+        /// The input texture is compressed using ETC texture compression.
+        /// The best ETC option will be selected given the image data.
+        /// Used on Android platforms.
+        /// This option should be preferred over <see cref="Etc1Compressed"/> whenever possible.
+        /// </summary>
+        EtcCompressed,
 
         /// <summary>
         /// The input texture is compressed using Adaptive Scalable Texture Compression. Used on some Mobile and Intel platforms.

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -172,6 +172,25 @@ internal static class BasisU
         return ExternalTool.Run("basisu", args, out stdOut, out stdErr, stdIn);
     }
 
+    /// <summary>
+    /// <para>
+    ///     Convert a <see cref="SurfaceFormat"/> into a <see cref="BasisUFormat"/>.
+    ///     Not all surface formats are supported. If the given format is not supported,
+    ///     then this method returns false, and the <see cref="error"/> out param will
+    ///     include an explanation of why the format isn't supported.
+    /// </para>
+    /// <para>
+    ///     The set of basisu formats are defined here,
+    ///     https://github.com/BinomialLLC/basis_universal/blob/master/transcoder/basisu_transcoder.h#L49
+    /// </para>
+    /// </summary>
+    /// <param name="format"></param>
+    /// <param name="basisUFormat"></param>
+    /// <param name="error"></param>
+    /// <returns>
+    ///     True if the <see cref="BasisUFormat"/> out param has been set.
+    ///     False otherwise, and the <see cref="error"/> out param will include an error message.
+    /// </returns>
     public static bool TryGetBasisUFormat(SurfaceFormat format, out BasisUFormat basisUFormat, out string error)
     {
         basisUFormat = default;

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -1,0 +1,427 @@
+using System;
+using System.IO;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using Microsoft.Xna.Framework.Graphics;
+using QoiSharp;
+using QoiSharp.Codec;
+using KtxSharp;
+using StbImageWriteSharp;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities;
+
+/// <summary>
+/// <para>
+/// BasisU has a set of supported formats, documented here,
+/// https://github.com/BinomialLLC/basis_universal/blob/master/transcoder/basisu_transcoder.h#L49
+/// </para>
+///
+/// <para>
+/// The <see cref="BasisUFormat"/> struct captures the enum value, the human readable name, and flag information
+/// for the various basisU formats that apply to Monogame.
+/// </para>
+/// </summary>
+internal struct BasisUFormat
+{
+    /// <summary>
+    /// BasisU uses an integer to represent texture formats on the CLI
+    /// </summary>
+    public int code;
+
+    /// <summary>
+    /// By default, basisU will assume that all input color formats are in sRGB.
+    /// If the format requires linear color space, that must be set manually.
+    /// </summary>
+    public bool isLinearColorSpace;
+
+    /// <summary>
+    /// The human readable name of the format
+    /// </summary>
+    public string name;
+
+    // Instead of constructing one of these yourself, please use one of the many predefined static class members.
+    private BasisUFormat(int code, string name, bool isLinearColorSpace=false)
+    {
+        this.code = code;
+        this.name = name;
+        this.isLinearColorSpace = isLinearColorSpace;
+    }
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.RgbEtc1"/>
+    /// Opaque only, returns RGB or alpha data if cDecodeFlagsTranscodeAlphaDataToOpaqueFormats flag is specified
+    /// </summary>
+    public static readonly BasisUFormat RgbEtc1 = new BasisUFormat(
+        code: 0,
+        name: "cTFETC1_RGB",
+        isLinearColorSpace: true
+    );
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.Rgba8Etc2"/>
+    /// Opaque+alpha, ETC2_EAC_A8 block followed by a ETC1 block, alpha channel will be opaque for opaque .basis files
+    /// </summary>
+    public static readonly BasisUFormat RgbaEtc2 = new BasisUFormat(
+        code: 1,
+        name: "cTFETC2_RGBA",
+        isLinearColorSpace: true
+    );
+
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.Rgba8Etc2"/>
+    /// Opaque+alpha, ETC2_EAC_A8 block followed by a ETC1 block, alpha channel will be opaque for opaque .basis files
+    /// </summary>
+    public static readonly BasisUFormat SRgbaEtc2 = new BasisUFormat(
+        code: 1,
+        name: "cTFETC2_RGBA",
+        isLinearColorSpace: false
+    );
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.RgbaAtcInterpolatedAlpha"/>
+    /// Opaque+alpha, alpha channel will be opaque for opaque .basis files. ATI ATC (GL_ATC_RGBA_INTERPOLATED_ALPHA_AMD)
+    /// </summary>
+    public static readonly BasisUFormat RgbaAtcInterpolatedAlpha = new BasisUFormat(
+        code: 12,
+        name: "cTFATC_RGBA",
+        isLinearColorSpace: true
+    );
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.Dxt1"/>
+    /// Opaque only, no punchthrough alpha support yet, transcodes alpha slice if cDecodeFlagsTranscodeAlphaDataToOpaqueFormats flag is specified
+    /// </summary>
+    public static readonly BasisUFormat Dxt1 = new BasisUFormat(
+        code: 2,
+        name: "cTFBC1_RGB",
+        isLinearColorSpace: true
+    );
+
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.Dxt1"/>
+    /// Opaque only, no punchthrough alpha support yet, transcodes alpha slice if cDecodeFlagsTranscodeAlphaDataToOpaqueFormats flag is specified
+    /// </summary>
+    public static readonly BasisUFormat Dxt1S = new BasisUFormat(
+        code: 2,
+        name: "cTFBC1_RGB",
+        isLinearColorSpace: false
+    );
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.Dxt5"/>
+    /// Opaque+alpha, BC4 followed by a BC1 block, alpha channel will be opaque for opaque .basis files
+    /// </summary>
+    public static readonly BasisUFormat Dxt5 = new BasisUFormat(
+        code: 3,
+        name: "cTFBC3_RGBA",
+        isLinearColorSpace: true
+    );
+
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.Dxt5"/>
+    /// Opaque+alpha, BC4 followed by a BC1 block, alpha channel will be opaque for opaque .basis files
+    /// </summary>
+    public static readonly BasisUFormat Dxt5S = new BasisUFormat(
+        code: 3,
+        name: "cTFBC3_RGBA",
+        isLinearColorSpace: false
+    );
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.RgbPvrtc4Bpp"/>
+    /// Opaque only, RGB or alpha if cDecodeFlagsTranscodeAlphaDataToOpaqueFormats flag is specified, nearly lowest quality of any texture format.
+    /// </summary>
+    public static readonly BasisUFormat RgbPvrtc4Bpp = new BasisUFormat(
+        code: 8,
+        name: "cTFPVRTC1_4_RGB",
+        isLinearColorSpace: true
+    );
+
+    /// <summary>
+    /// <see cref="SurfaceFormat.RgbaPvrtc4Bpp"/>
+    ///  Opaque+alpha, most useful for simple opacity maps. If .basis file doesn't have alpha cTFPVRTC1_4_RGB will be used instead. Lowest quality of any supported texture format.
+    /// </summary>
+    public static readonly BasisUFormat RgbaPvrtc4Bpp = new BasisUFormat(
+        code: 9,
+        name: "cTFPVRTC1_4_RGBA",
+        isLinearColorSpace: true
+    );
+
+
+}
+
+/// <summary>
+/// Utilities for using the Basis Universal tool.
+/// </summary>
+internal static class BasisU
+{
+    /// <summary>
+    /// A lightweight wrapper to invoke the Basis Universal tool (called 'basisu').
+    /// </summary>
+    /// <param name="args">The args to pass to basisu. These args are passed directly to the tool with no processing. </param>
+    /// <param name="stdOut">The standard output buffer from the basisu process</param>
+    /// <param name="stdErr">The standard error buffer from the basisu process</param>
+    /// <param name="stdIn">The standard input buffer for the basisu process. By default, no standard input is sent to the process. </param>
+    /// <returns>The exit code for the basisu process. </returns>
+    public static int Run(string args, out string stdOut, out string stdErr, string stdIn=null)
+    {
+        return ExternalTool.Run("basisu", args, out stdOut, out stdErr, stdIn);
+    }
+
+    public static bool TryGetBasisUFormat(SurfaceFormat format, out BasisUFormat basisUFormat, out string error)
+    {
+        basisUFormat = default;
+        error = "";
+        switch (format)
+        {
+            // ATC formats
+            case SurfaceFormat.RgbaAtcExplicitAlpha:
+                // explicit ATC rgba isn't supported. RGB is, but not RGBA explicit.
+                //  Here is a doc describing the difference between explicit and interpolated RGBA ATC
+                //  https://registry.khronos.org/OpenGL/extensions/AMD/AMD_compressed_ATC_texture.txt
+                error = "basisU does not support explicit ATC.";
+                return false;
+            case SurfaceFormat.RgbaAtcInterpolatedAlpha:
+                basisUFormat = BasisUFormat.RgbaAtcInterpolatedAlpha;
+                return true;
+
+            // ETC formats
+            case SurfaceFormat.RgbEtc1:
+                basisUFormat = BasisUFormat.RgbEtc1;
+                return true;
+            case SurfaceFormat.Rgba8Etc2:
+                basisUFormat = BasisUFormat.RgbaEtc2;
+                return true;
+            case SurfaceFormat.SRgb8A8Etc2:
+                basisUFormat = BasisUFormat.SRgbaEtc2;
+                return true;
+
+            // these ETC formats are not supported in BasisU
+            //  https://github.com/BinomialLLC/basis_universal/issues/216
+            case SurfaceFormat.Rgb8A1Etc2:
+            case SurfaceFormat.Srgb8A1Etc2:
+                error = "basisU does not support RGB8 A1 ETC2";
+                return false;
+            case SurfaceFormat.Rgb8Etc2:
+            case SurfaceFormat.Srgb8Etc2:
+                error = "basisU does not support RGB8 ETC2";
+                return false;
+
+            // DXT formats (also called BCn)
+            case SurfaceFormat.Dxt1:// dxt1 is often called Bc1
+                basisUFormat = BasisUFormat.Dxt1;
+                return true;
+            case SurfaceFormat.Dxt1SRgb:
+                basisUFormat = BasisUFormat.Dxt1S;
+                return true;
+            case SurfaceFormat.Dxt1a:
+                error = "Dxt1a is not supported in basisU; the docs state, 'Opaque only, no punchthrough alpha support yet'";
+                return false;
+            case SurfaceFormat.Dxt3: // dtx3 is often called Bc2
+            case SurfaceFormat.Dxt3SRgb:
+                // Dxt3 is not supported by basisU
+                //  https://github.com/BinomialLLC/basis_universal/issues/63#issuecomment-535778254
+                // error = "Dxt3 is not supported in basisU. Dxt3 is rarely used. Use Dxt5 instead.";
+                // return false;
+                basisUFormat = BasisUFormat.Dxt5; // best effort?
+                return true;
+            case SurfaceFormat.Dxt5: // dxt5 is often called Bc3
+                basisUFormat = BasisUFormat.Dxt5;
+                return true;
+            case SurfaceFormat.Dxt5SRgb:
+                basisUFormat = BasisUFormat.Dxt5S;
+                return true;
+
+            // POWERVR Texture Compression
+            case SurfaceFormat.RgbPvrtc2Bpp:
+            case SurfaceFormat.RgbaPvrtc2Bpp:
+                error = "PowerVR 2 bytes per pixel formats are not supported in basisU";
+                return false;
+
+            case SurfaceFormat.RgbPvrtc4Bpp:
+                basisUFormat = BasisUFormat.RgbPvrtc4Bpp;
+                return true;
+            case SurfaceFormat.RgbaPvrtc4Bpp:
+                basisUFormat = BasisUFormat.RgbaPvrtc4Bpp;
+                return true;
+
+            default:
+                // it is slightly redundant to return false in the default case when there are
+                //  explicitly listed false returns throughout unsupported formats.
+                //  But it is valuable to be explicit about the formats that are not supported
+                //  as of July 18th, 2024.
+                error = "unsupported";
+                return false;
+        }
+    }
+
+    public static bool TryEncodeBytes(
+        BitmapContent sourceBitmap,
+        int width,
+        int height,
+        bool hasAlpha,
+        bool isLinearColor,
+        SurfaceFormat format,
+        out byte[] encodedBytes)
+    {
+        encodedBytes = Array.Empty<byte>();
+
+        if (!TryGetBasisUFormat(format, out var basisUFormat, out _))
+        {
+            // TODO: is there a way to log?
+            return false;
+        }
+
+        if (!TryWritePngFile(sourceBitmap, width, height, hasAlpha, isLinearColor, out var imageFile))
+        {
+            return false;
+        }
+
+        var intermediateFileName = imageFile + ".ktx";
+
+        if (!TryBuildIntermediateFile(imageFile, intermediateFileName, out var stdErr))
+        {
+            return false;
+        }
+
+        if (!TryUnpackKtx(intermediateFileName, basisUFormat, out var ktxFileName))
+        {
+            return false;
+        }
+
+        if (!TryReadKtx(ktxFileName, out encodedBytes))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static unsafe bool TryWritePngFile(
+        BitmapContent sourceBitmap,
+        int width,
+        int height,
+        bool hasAlpha,
+        bool isLinearColor,
+        out string pngFileName)
+    {
+        pngFileName = $"tempImage_{Guid.NewGuid().ToString()}.png"; // TODO: get a project relative path.
+        using var fileStream = File.OpenWrite(pngFileName);
+
+        // in order to save a png, we need a colorBitmap.
+        var colorBitmap = new PixelBitmapContent<Color>(sourceBitmap.Width, sourceBitmap.Height);
+        BitmapContent.Copy(sourceBitmap, colorBitmap);
+
+        var data = colorBitmap.GetPixelData();
+        var writer = new ImageWriter(); // TODO: cache this instance.
+        writer.WritePng(data, colorBitmap.Width, colorBitmap.Height, ColorComponents.RedGreenBlueAlpha, fileStream);
+        fileStream.Close();
+        return true;
+    }
+
+    public static bool TryWriteQoiFile(
+        byte[] pixelBytes,
+        int width,
+        int height,
+        bool hasAlpha,
+        bool isLinearColor,
+        out string qoiFilePath)
+    {
+        var channels = hasAlpha ? Channels.RgbWithAlpha : Channels.Rgb;
+        var colorSpace = isLinearColor ? ColorSpace.Linear : ColorSpace.SRgb;
+        var image = new QoiImage(pixelBytes, width, height, channels, colorSpace);
+        var bytes = QoiEncoder.Encode(image);
+
+
+        qoiFilePath = $"tempImage_{Guid.NewGuid().ToString()}.qoi"; // TODO: get a project relative path.
+        File.WriteAllBytes(qoiFilePath, bytes);
+        return true;
+    }
+
+    public static bool TryReadKtx(string inputKtxFileName, out byte[] compressedBytes)
+    {
+        var bytes = File.ReadAllBytes(inputKtxFileName);
+        using var stream = new MemoryStream(bytes);
+        // KtxLoader.CheckIfInputIsValid()
+        var ktx = KtxLoader.LoadInput(stream);
+
+        compressedBytes = ktx.textureData.textureDataOfMipmapLevel[0];
+        return true;
+    }
+
+    public static bool TryUnpackKtx(
+        string basisFileName,
+        BasisUFormat basisUFormat,
+        out string outputKtxFileName
+    )
+    {
+        outputKtxFileName = null;
+
+        // taken from the basisu docs, https://github.com/MonoGame/MonoGame.Tool.BasisUniversal
+        //  basisu -unpack foo.ktx2 -ktx_only -linear -format_only 2
+        var linearFlag = basisUFormat.isLinearColorSpace ? "-linear" : "";
+        // var linearFlag = "";
+        var argStr = $"-unpack -file {basisFileName} -ktx_only -format_only {basisUFormat.code} {linearFlag}";
+        var exitCode = Run(
+            args: argStr,
+            stdOut: out var stdOut,
+            stdErr: out _);
+        // TODO: is there a standard logging practice to log stdErr/stdOut if the exitCode is non-zero?
+        var isSuccess = exitCode == 0;
+        if (!isSuccess)
+            return false;
+
+
+        // standard output should have many lines of output, where close to the end
+        //  it should log the output path.
+        //  Example:
+        //   Transcode of layer 0 level 0 face 0 res 1800x1350 format ATC_RGBA succeeded
+        //   Wrote KTX file "inputFile_transcoded_ATC_RGBA_0000.ktx"
+        //   Success
+        //
+        //  this output needs to be captured later.
+        var lines = stdOut.Split(
+            separator: Environment.NewLine,
+            options: StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
+        );
+
+        // move backwards through the lines because the output we are looking for
+        //  should be at the end of the output
+        const string logPrefix = "Wrote KTX file \"";
+        const string logSuffix = "\"";
+        for (var i = lines.Length - 1; i >= 0; i--)
+        {
+            var line = lines[i];
+            if (!line.StartsWith(logPrefix)) continue;
+
+            var fileNameLength = line.Length - logPrefix.Length - logSuffix.Length;
+            outputKtxFileName = line.Substring(logPrefix.Length, fileNameLength);
+            break;
+        }
+
+        var parsedKtxFileName = !string.IsNullOrEmpty(outputKtxFileName);
+
+        return parsedKtxFileName;
+    }
+
+    public static bool TryBuildIntermediateFile(
+        string imageFileName,
+        string intermediateFileName,
+        out string stdErr)
+    {
+        var absImageFileName = Path.GetFullPath(imageFileName);
+        // taken from the basisu docs, https://github.com/MonoGame/MonoGame.Tool.BasisUniversal
+        //  basisu -file foo.png -ktx2
+        // var uastcFlag = "-uastc";
+        var argStr = $"-file {absImageFileName} -uastc -ktx2 -output_file {intermediateFileName}";
+        var exitCode = Run(
+            args: argStr,
+            stdOut: out _,
+            stdErr: out stdErr);
+        // TODO: is there a standard logging practice to log stdErr/stdOut if the exitCode is non-zero?
+        var isSuccess = exitCode == 0;
+        return isSuccess;
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -270,7 +270,7 @@ internal static class BasisU
     {
         encodedBytes = Array.Empty<byte>();
 
-        if (!TryGetBasisUFormat(format, out var basisUFormat, out _))
+        if (!TryGetBasisUFormat(format, out var basisUFormat, out var basisUError))
         {
             // TODO: is there a way to log?
             return false;
@@ -346,11 +346,12 @@ internal static class BasisU
         //  basisu -unpack foo.ktx2 -ktx_only -linear -format_only 2
         var linearFlag = basisUFormat.isLinearColorSpace ? "-linear" : "";
         // var linearFlag = "";
-        var argStr = $"-unpack -file {basisFileName} -ktx_only -format_only {basisUFormat.code} {linearFlag}";
+        // -ktx_only
+        var argStr = $"-unpack -file {basisFileName}  -format_only {basisUFormat.code} {linearFlag}";
         var exitCode = Run(
             args: argStr,
             stdOut: out var stdOut,
-            stdErr: out _);
+            stdErr: out var stdErr);
         // TODO: is there a standard logging practice to log stdErr/stdOut if the exitCode is non-zero?
         var isSuccess = exitCode == 0;
         if (!isSuccess)
@@ -401,7 +402,7 @@ internal static class BasisU
         var argStr = $"-file {absImageFileName} -uastc -ktx2 -output_file {intermediateFileName}";
         var exitCode = Run(
             args: argStr,
-            stdOut: out _,
+            stdOut: out var stdOut,
             stdErr: out stdErr);
         // TODO: is there a standard logging practice to log stdErr/stdOut if the exitCode is non-zero?
         var isSuccess = exitCode == 0;

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -6,9 +6,7 @@ using System;
 using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
-using KtxSharp;
 using MonoGame.Framework.Content;
-using StbImageWriteSharp;
 
 namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 
@@ -21,6 +19,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 /// <para>
 /// The <see cref="BasisUFormat"/> struct captures the enum value, the human readable name, and flag information
 /// for the various basisU formats that apply to Monogame.
+/// </para>
+/// <para>
+/// This is marked as internal because it is not part of the original XNA api.
 /// </para>
 /// </summary>
 internal struct BasisUFormat
@@ -185,6 +186,9 @@ internal struct BasisUFormat
 
 /// <summary>
 /// Utilities for using the Basis Universal tool.
+/// <para>
+/// This is marked as internal because it is not part of the original XNA api.
+/// </para>
 /// </summary>
 internal static class BasisU
 {

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -397,6 +397,7 @@ internal static class BasisU
     {
         var context = ContextScopeFactory.ActiveContext;
 
+        // unfortunately, basisU requires an input _file_.
         pngFileName = $"tempImage_{Guid.NewGuid().ToString()}.png"; // TODO: get a project relative path.
         pngFileName = Path.Combine(context.IntermediateDirectory, pngFileName);
         using var fileStream = File.OpenWrite(pngFileName);

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BasisUHelpers.cs
@@ -1,9 +1,11 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
 using System;
 using System.IO;
 using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
 using Microsoft.Xna.Framework.Graphics;
-using QoiSharp;
-using QoiSharp.Codec;
 using KtxSharp;
 using StbImageWriteSharp;
 
@@ -299,7 +301,7 @@ internal static class BasisU
         return true;
     }
 
-    public static unsafe bool TryWritePngFile(
+    public static bool TryWritePngFile(
         BitmapContent sourceBitmap,
         int width,
         int height,
@@ -318,25 +320,6 @@ internal static class BasisU
         var writer = new ImageWriter(); // TODO: cache this instance.
         writer.WritePng(data, colorBitmap.Width, colorBitmap.Height, ColorComponents.RedGreenBlueAlpha, fileStream);
         fileStream.Close();
-        return true;
-    }
-
-    public static bool TryWriteQoiFile(
-        byte[] pixelBytes,
-        int width,
-        int height,
-        bool hasAlpha,
-        bool isLinearColor,
-        out string qoiFilePath)
-    {
-        var channels = hasAlpha ? Channels.RgbWithAlpha : Channels.Rgb;
-        var colorSpace = isLinearColor ? ColorSpace.Linear : ColorSpace.SRgb;
-        var image = new QoiImage(pixelBytes, width, height, channels, colorSpace);
-        var bytes = QoiEncoder.Encode(image);
-
-
-        qoiFilePath = $"tempImage_{Guid.NewGuid().ToString()}.qoi"; // TODO: get a project relative path.
-        File.WriteAllBytes(qoiFilePath, bytes);
         return true;
     }
 

--- a/MonoGame.Framework.Content.Pipeline/Utilities/BcnHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/BcnHelpers.cs
@@ -1,0 +1,61 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.IO;
+using BCnEncoder.Encoder;
+using BCnEncoder.Shared;
+using KtxSharp;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities;
+
+/// <summary>
+/// The <see cref="Encode"/> method uses the https://github.com/Nominom/BCnEncoder.NET/tree/master
+/// library to encode various block based compression formats
+/// </summary>
+public static class BcnUtil
+{
+    /// <summary>
+    /// Compress the given <see cref="sourceBitmap"/> to the desired block format <see cref="destinationFormat"/>.
+    /// No files will be written to disk, and no external tools are invoked.
+    /// </summary>
+    /// <param name="sourceBitmap"></param>
+    /// <param name="destinationFormat"></param>
+    /// <param name="compressedBytes"></param>
+    public static void Encode(
+        BitmapContent sourceBitmap,
+        CompressionFormat destinationFormat,
+        out byte[] compressedBytes)
+    {
+        // first, copy the bitmap to a local color (rgba32) format
+        var colorBitmap = new PixelBitmapContent<Color>(sourceBitmap.Width, sourceBitmap.Height);
+        BitmapContent.Copy(sourceBitmap, colorBitmap);
+        var data = colorBitmap.GetPixelData();
+
+
+        var dataSpan = new ReadOnlySpan<byte>(data);
+        var ktxStream = new MemoryStream();
+
+        // setup the encoder
+        BcEncoder encoder = new BcEncoder
+        {
+            OutputOptions =
+            {
+                GenerateMipMaps = false,
+                Quality = CompressionQuality.BestQuality,
+                Format = destinationFormat,
+                FileFormat = OutputFileFormat.Ktx
+            }
+        };
+
+        // encode to ktx format
+        encoder.EncodeToStream(dataSpan, sourceBitmap.Width, sourceBitmap.Height, PixelFormat.Rgba32, ktxStream);
+
+        // decode the ktx format and find the raw bytes
+        ktxStream.Seek(0, SeekOrigin.Begin);
+        var ktx = KtxLoader.LoadInput(ktxStream);
+        compressedBytes = ktx.textureData.textureDataOfMipmapLevel[0];
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
@@ -1,0 +1,240 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using MonoGame.Framework.Content;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
+{
+
+    /// <summary>
+    /// The <see cref="CrunchFormat"/> holds all information required to invoke the
+    /// Crunch tool for a given configuration.
+    ///
+    /// As of August 19 2024, the only important field is the <see cref="formatString"/>,
+    /// but Crunch supports many compression-option flags that may become important.
+    ///
+    /// </summary>
+    internal struct CrunchFormat
+    {
+        /// <summary>
+        /// Represents the format for the compression. The following is taken from the --help invocation of Crunch as of August 19 2024.
+        /// <para>
+        ///
+        /// All supported texture formats (Note: .CRN only supports DXTn pixel formats):
+        /// -DXT1
+        /// -DXT2
+        /// -DXT3
+        /// -DXT4
+        /// -DXT5
+        /// -3DC
+        /// -DXN
+        /// -DXT5A
+        /// -DXT5_CCxY
+        /// -DXT5_xGxR
+        /// -DXT5_xGBR
+        /// -DXT5_AGBR
+        /// -DXT1A
+        /// -ETC1
+        /// -ETC2
+        /// -ETC2A
+        /// -ETC1S
+        /// -ETC2AS
+        /// -R8G8B8
+        /// -L8
+        /// -A8
+        /// -A8L8
+        /// -A8R8G8B8
+        ///
+        /// </para>
+        /// </summary>
+        public string formatString;
+
+        // private constructor because all known formats should be declared as static-readonlys
+        private CrunchFormat(string formatString)
+        {
+            this.formatString = formatString;
+        }
+
+        public override string ToString()
+        {
+            return $"crunch(name={formatString})";
+        }
+
+        /// <summary>
+        /// Dxt3 (or Bc2)
+        /// </summary>
+        public static readonly CrunchFormat Dxt3 = new CrunchFormat
+        {
+            formatString = "DXT3"
+        };
+
+        /// <summary>
+        /// Dxt1 (or Bc1)
+        /// </summary>
+        public static readonly CrunchFormat Dxt1 = new CrunchFormat
+        {
+            formatString = "DXT1A"
+        };
+
+        /// <summary>
+        /// Dxt1a is a variant of Dxt1 that supports a 1-bit alpha
+        /// </summary>
+        public static readonly CrunchFormat Dxt1A = new CrunchFormat
+        {
+            formatString = "DXT1A"
+        };
+
+        /// <summary>
+        /// Dxt5 (or Bc3)
+        /// </summary>
+        public static readonly CrunchFormat Dxt5 = new CrunchFormat
+        {
+            formatString = "DXT5"
+        };
+
+        /// <summary>
+        /// Etc1
+        /// </summary>
+        public static readonly CrunchFormat Etc1 = new CrunchFormat
+        {
+            formatString = "ETC1"
+        };
+
+        /// <summary>
+        /// Etc2A supports alpha
+        /// </summary>
+        public static readonly CrunchFormat Etc2A = new CrunchFormat
+        {
+            formatString = "ETC2A"
+        };
+    }
+    internal static class Crunch
+    {
+        /// <summary>
+        /// A lightweight wrapper to invoke the Crunch tool (called 'crunch').
+        /// https://github.com/MonoGame/MonoGame.Tool.Crunch
+        /// </summary>
+        /// <param name="args">The args to pass to crunch. These args are passed directly to the tool with no processing. </param>
+        /// <param name="stdOut">The standard output buffer from the crunch process</param>
+        /// <param name="stdErr">The standard error buffer from the crunch process</param>
+        /// <returns>The exit code for the basisu process. </returns>
+        private static int Run(string args, out string stdOut, out string stdErr)
+        {
+            return ExternalTool.RunDotnetTool("mgcb-crunch", args, out stdOut, out stdErr);
+        }
+
+        /// <summary>
+        /// This method will use Crunch to compress the <see cref="sourceBitmap"/> into the
+        /// desired <see cref="CrunchFormat"/>.
+        ///
+        /// <para>
+        /// This method can only be called if there is an active context in the <see cref="ContextScopeFactory"/>
+        /// </para>
+        /// </summary>
+        /// <param name="sourceBitmap">
+        /// The <see cref="BitmapContent"/> to be compressed.
+        /// </param>
+        /// <param name="crunchFormat">
+        /// The desired <see cref="CrunchFormat"/> to use.
+        /// </param>
+        /// <param name="encodedBytes">
+        /// The resulting compressed bytes.
+        /// </param>
+        /// <exception cref="PipelineException"></exception>
+        public static void EncodeBytes(
+            BitmapContent sourceBitmap,
+            CrunchFormat crunchFormat,
+            out byte[] encodedBytes
+        )
+        {
+            if (!TryEncodeBytes(
+                    sourceBitmap: sourceBitmap,
+                    crunchFormat: crunchFormat,
+                    encodedBytes: out encodedBytes,
+                    failureMessage: out var error))
+            {
+                throw new PipelineException($"Failed to crunch. {error}");
+            }
+        }
+
+        private static bool TryEncodeBytes(
+            BitmapContent sourceBitmap,
+            CrunchFormat crunchFormat,
+            out byte[] encodedBytes,
+            out string failureMessage)
+        {
+            failureMessage = null;
+            encodedBytes = Array.Empty<byte>();
+
+            // these files will likely be created during this method, and should be
+            //  deleted before exiting the function.
+            string pngFileName = null;
+            string ktxFileName = null;
+
+            try
+            {
+                PngFileHelper.WritePngToIntermediate(sourceBitmap, out pngFileName);
+
+                ktxFileName = pngFileName + ".ktx";
+
+                if (!TryCrunch(crunchFormat, pngFileName, ktxFileName, out var error))
+                {
+                    failureMessage = error;
+                    return false;
+                }
+
+                if (!KtxFileHelper.TryReadKtx(ktxFileName, out encodedBytes))
+                {
+                    failureMessage = "unable to read unpacked ktx file";
+                    return false;
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(pngFileName))
+                {
+                    ExternalTool.DeleteFile(pngFileName);
+                }
+
+                if (!string.IsNullOrEmpty(ktxFileName))
+                {
+                    ExternalTool.DeleteFile(ktxFileName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Run the crunch tool for a given format and generate a ktx file as output
+        /// </summary>
+        private static bool TryCrunch(
+            CrunchFormat format,
+            string pngFileName,
+            string intermediateFileName,
+            out string errorMessage
+        )
+        {
+            errorMessage = null;
+            var argStr = $"-file {pngFileName} -{format.formatString} -out {intermediateFileName} -fileformat ktx -forceprimaryencoding -noNormalDetection";
+            var exitCode = Run(
+                args: argStr,
+                stdOut: out var stdOut,
+                stdErr: out var stdErr
+            );
+
+            var wasSuccess = exitCode == 0;
+            if (!wasSuccess)
+            {
+                errorMessage = $"failed to use crunch tool. args=[{argStr}] stdOut=[{stdOut}] stdErr=[{stdErr}] exitCode=[{exitCode}]";
+            }
+
+            return wasSuccess;
+        }
+
+    }
+}
+

--- a/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/CrunchHelpers.cs
@@ -10,12 +10,19 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
 {
 
     /// <summary>
+    /// <para>
     /// The <see cref="CrunchFormat"/> holds all information required to invoke the
     /// Crunch tool for a given configuration.
+    /// </para>
     ///
+    /// <para>
     /// As of August 19 2024, the only important field is the <see cref="formatString"/>,
     /// but Crunch supports many compression-option flags that may become important.
+    /// </para>
     ///
+    /// <para>
+    /// This is marked as internal because it is not part of the original XNA api.
+    /// </para>
     /// </summary>
     internal struct CrunchFormat
     {
@@ -111,6 +118,13 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities
             formatString = "ETC2A"
         };
     }
+
+    /// <summary>
+    /// Utilities for using the Crunch tool.
+    /// <para>
+    /// This is marked as internal because it is not part of the original XNA api.
+    /// </para>
+    /// </summary>
     internal static class Crunch
     {
         /// <summary>

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FileHelpers.cs
@@ -1,0 +1,81 @@
+// MonoGame - Copyright (C) MonoGame Foundation, Inc
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.IO;
+using KtxSharp;
+using Microsoft.Xna.Framework.Content.Pipeline.Graphics;
+using MonoGame.Framework.Content;
+using StbImageWriteSharp;
+
+namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities;
+
+/// <summary>
+/// Utility methods for interacting with .png files
+/// </summary>
+internal static class PngFileHelper
+{
+    /// <summary>
+    /// Convert a <see cref="BitmapContent"/> into a <see cref="PixelBitmapContent{Color}"/> and write
+    /// it to disk as a png file.
+    ///
+    /// This method requires that there is an active context in the <see cref="ContextScopeFactory"/>,
+    /// otherwise a <see cref="PipelineException"/> will be thrown
+    /// </summary>
+    /// <param name="sourceBitmap">the bitmap to write to disk</param>
+    /// <param name="pngFileName">
+    /// The resulting name of the png image that was written.
+    /// This method will not delete the image.
+    /// </param>
+    public static void WritePngToIntermediate(
+        BitmapContent sourceBitmap,
+        out string pngFileName)
+    {
+        var context = ContextScopeFactory.ActiveContext;
+
+        // unfortunately, basisU requires an input _file_.
+        pngFileName = $"tempImage_{Guid.NewGuid().ToString()}.png"; // TODO: get a project relative path.
+        pngFileName = Path.Combine(context.IntermediateDirectory, pngFileName);
+        using var fileStream = File.OpenWrite(pngFileName);
+
+        // in order to save a png, we need a colorBitmap.
+        var colorBitmap = new PixelBitmapContent<Color>(sourceBitmap.Width, sourceBitmap.Height);
+        BitmapContent.Copy(sourceBitmap, colorBitmap);
+
+        var data = colorBitmap.GetPixelData();
+        var writer = new ImageWriter();
+        writer.WritePng(data, colorBitmap.Width, colorBitmap.Height, ColorComponents.RedGreenBlueAlpha, fileStream);
+        fileStream.Close();
+    }
+}
+
+/// <summary>
+/// Utility methods for .ktx files
+/// </summary>
+internal static class KtxFileHelper
+{
+    /// <summary>
+    /// Read in a given ktx file and extract the compressed bytes stored within the file.
+    ///
+    /// The ktx file format can hold data for multiple mip levels, but
+    /// As of August 19th 2024, this method only returns the data for the first mip level.
+    /// </summary>
+    /// <param name="inputKtxFileName">the path to the ktx file</param>
+    /// <param name="compressedBytes">the compressed bytes will be stored here.</param>
+    /// <returns></returns>
+    public static bool TryReadKtx(string inputKtxFileName, out byte[] compressedBytes)
+    {
+        compressedBytes = Array.Empty<byte>();
+        if (!File.Exists(inputKtxFileName))
+        {
+            return false;
+        }
+
+        var bytes = File.ReadAllBytes(inputKtxFileName);
+        using var stream = new MemoryStream(bytes);
+        var ktx = KtxLoader.LoadInput(stream);
+        compressedBytes = ktx.textureData.textureDataOfMipmapLevel[0];
+        return true;
+    }
+}

--- a/MonoGame.Framework.Content.Pipeline/Utilities/FileHelpers.cs
+++ b/MonoGame.Framework.Content.Pipeline/Utilities/FileHelpers.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Utilities;
 
 /// <summary>
 /// Utility methods for interacting with .png files
+/// <para>
+/// This is marked as internal because it is not part of the original XNA api.
+/// </para>
 /// </summary>
 internal static class PngFileHelper
 {
@@ -52,6 +55,9 @@ internal static class PngFileHelper
 
 /// <summary>
 /// Utility methods for .ktx files
+/// <para>
+/// This is marked as internal because it is not part of the original XNA api.
+/// </para>
 /// </summary>
 internal static class KtxFileHelper
 {

--- a/MonoGame.Framework/Graphics/SurfaceFormat.cs
+++ b/MonoGame.Framework/Graphics/SurfaceFormat.cs
@@ -183,6 +183,10 @@ namespace Microsoft.Xna.Framework.Graphics
         /// Etc2 SRGB8A8 EAC (Android/iOS withh OpenglES 3.0)
 		/// </summary>
         SRgb8A8Etc2 = 95,
+        /// <summary>
+        /// Adaptive scalable texture compression ; 4x4 matrix using rgba channel interpretation
+        /// </summary>
+        ASTC_4x4_Rgba = 96,
 
         #endregion
     }

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -252,13 +252,9 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCompress_Atc_Explicit()
         {
-            // unfortunately, neither basisU or crunch support ATC explicit.
-            //  in this case, a PipelineException is thrown, and this test validates it.
+            // validate that we can compress an atc explicit texture
             using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
-            Assert.Throws<PipelineException>(() =>
-            {
-                BitmapConvert(typeof(AtcExplicitBitmapContent), Color.Red, 64, 64);
-            });
+            BitmapConvert(typeof(AtcExplicitBitmapContent), Color.Red, 64, 64);
         }
 
 

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -249,6 +249,18 @@ namespace MonoGame.Tests.ContentPipeline
             BitmapConvert(typeof(AtcInterpolatedBitmapContent), Color.Red, 64, 64);
         }
 
+        [Test]
+        public void BitmapCompress_Atc_Explicit()
+        {
+            // unfortunately, neither basisU or crunch support ATC explicit.
+            //  in this case, a PipelineException is thrown, and this test validates it.
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
+            Assert.Throws<PipelineException>(() =>
+            {
+                BitmapConvert(typeof(AtcExplicitBitmapContent), Color.Red, 64, 64);
+            });
+        }
+
 
         [Test]
         public void BitmapCompress_Etc1()

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -5,7 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.Xna.Framework.Content.Pipeline;
 using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Framework.Content;
+using MonoGame.Tools.Tests;
 
 namespace MonoGame.Tests.ContentPipeline
 {
@@ -224,12 +227,14 @@ namespace MonoGame.Tests.ContentPipeline
 
         static void BitmapConvertAssert(Type bitmapType, Color color, int w, int h, int range)
         {
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
             var b = BitmapConvert(bitmapType, color, w, h);
             BitmapAssert(b, color, range);
         }
 
         static void BitmapConvertAssert(Type bitmapType, Color color, int w, int h, Color compare, int range)
         {
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
             var b = BitmapConvert(bitmapType, color, w, h);
             BitmapAssert(b, compare, range);
         }
@@ -246,6 +251,7 @@ namespace MonoGame.Tests.ContentPipeline
         public void BitmapCompress_Etc1()
         {
             // validate that we can compress an atc interpolated texture
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
             BitmapConvert(typeof(Etc1BitmapContent), Color.Red, 64, 64);
         }
 
@@ -253,11 +259,17 @@ namespace MonoGame.Tests.ContentPipeline
         public void BitmapCompress_Pvrtc()
         {
             // validate that we can compress a pvrtc rgb texture
-            BitmapConvert(typeof(PvrtcRgb4BitmapContent), Color.Red, 64, 64);
+            using (var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext()))
+            {
+                BitmapConvert(typeof(PvrtcRgb4BitmapContent), Color.Red, 64, 64);
+            }
+
 
             // validate that we can compress a pvrtc rgb texture
-            BitmapConvert(typeof(PvrtcRgba4BitmapContent), Color.Red, 64, 64);
-
+            using (var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext()))
+            {
+                BitmapConvert(typeof(PvrtcRgba4BitmapContent), Color.Red, 64, 64);
+            }
         }
 
         [Test]

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -215,10 +215,10 @@ namespace MonoGame.Tests.ContentPipeline
 
             for (var p = 0; p < rgba.Length; p += 4)
             {
-                Assert.That(rgba[p + 0], Is.EqualTo(color.R).Within(range));
-                Assert.That(rgba[p + 1], Is.EqualTo(color.G).Within(range));
-                Assert.That(rgba[p + 2], Is.EqualTo(color.B).Within(range));
-                Assert.That(rgba[p + 3], Is.EqualTo(color.A).Within(range));
+                Assert.That(rgba[p + 0], Is.EqualTo(color.R).Within(range), "Red is not within tolerance");
+                Assert.That(rgba[p + 1], Is.EqualTo(color.G).Within(range), "Green is not within tolerance");
+                Assert.That(rgba[p + 2], Is.EqualTo(color.B).Within(range), "Blue is not within tolerance");
+                Assert.That(rgba[p + 3], Is.EqualTo(color.A).Within(range), "Alpha is not within tolerance");
             }
         }
 
@@ -235,20 +235,36 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
-        public void BitmapCompress()
+        public void BitmapCompress_Dxt1()
         {
-            var Transparent = new Color(0, 0, 0, 0);
-            var Grey16Premult = new Color(16, 16, 16, 16);
             BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Red, 64, 64, 0);
             BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Green, 32, 34, 2);
             BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Blue, 8, 9, 0);
-            BitmapConvertAssert(typeof(Dxt1BitmapContent), Transparent, 16, 16, 0);
-            //BitmapConvertAssert(typeof(Dxt1BitmapContent), Grey16Premult, 16, 16, Transparent, 0);
+
+            // BasisU does not support Bcn1 alpha punch-through, also known as Dxt1a. Therefor, the alpha channel is lost and always assumed to be opaque.
+            //  this is a test regression, and the following line _used_ to work.
+            //BitmapConvertAssert(typeof(Dxt1BitmapContent), new Color(0, 0, 0, 0), 16, 16, 0);
+        }
+
+        [Test]
+        public void BitmapCompress_Dxt3()
+        {
+            var Transparent = new Color(0, 0, 0, 0);
+            var Grey16Premult = new Color(16, 16, 16, 16);
+
             BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Red, 64, 64, 0);
             BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Green, 32, 34, 2);
             BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Blue, 8, 9, 0);
             BitmapConvertAssert(typeof(Dxt3BitmapContent), Transparent, 16, 16, 0);
             BitmapConvertAssert(typeof(Dxt3BitmapContent), Grey16Premult, 16, 16, Grey16Premult, 1);
+        }
+
+        [Test]
+        public void BitmapCompress_Dxt5()
+        {
+            var Transparent = new Color(0, 0, 0, 0);
+            var Grey16Premult = new Color(16, 16, 16, 16);
+
             BitmapConvertAssert(typeof(Dxt5BitmapContent), Color.Red, 64, 64, 0);
             BitmapConvertAssert(typeof(Dxt5BitmapContent), Color.Green, 32, 34, 2);
             BitmapConvertAssert(typeof(Dxt5BitmapContent), Color.Blue, 8, 9, 0);

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -264,6 +264,15 @@ namespace MonoGame.Tests.ContentPipeline
             BitmapConvert(typeof(Etc2BitmapContent), Color.Red, 64, 64);
         }
 
+
+        [Test]
+        public void BitmapCompress_Astc()
+        {
+            // validate that we can compress an atc interpolated texture
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
+            BitmapConvert(typeof(AstcBitmapContent), Color.Red, 64, 64);
+        }
+
         [Test]
         public void BitmapCompress_Pvrtc()
         {
@@ -290,20 +299,20 @@ namespace MonoGame.Tests.ContentPipeline
 
             // BasisU does not support Bcn1 alpha punch-through, also known as Dxt1a. Therefor, the alpha channel is lost and always assumed to be opaque.
             //  this is a test regression, and the following line _used_ to work.
-            //BitmapConvertAssert(typeof(Dxt1BitmapContent), new Color(0, 0, 0, 0), 16, 16, 0);
+            // BitmapConvertAssert(typeof(Dxt1BitmapContent), new Color(0, 0, 0, 0), 16, 16, 0);
+            Assert.Catch<NotSupportedException>(() =>
+            {
+                BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Transparent, 64, 64, 0);
+            });
         }
 
         [Test]
         public void BitmapCompress_Dxt3()
         {
-            var Transparent = new Color(0, 0, 0, 0);
-            var Grey16Premult = new Color(16, 16, 16, 16);
-
-            BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Red, 64, 64, 0);
-            BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Green, 32, 34, 2);
-            BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Blue, 8, 9, 0);
-            BitmapConvertAssert(typeof(Dxt3BitmapContent), Transparent, 16, 16, 0);
-            BitmapConvertAssert(typeof(Dxt3BitmapContent), Grey16Premult, 16, 16, Grey16Premult, 1);
+            Assert.Catch<NotSupportedException>(() =>
+            {
+                BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Gray, 64, 64, 0);
+            });
         }
 
         [Test]

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -235,6 +235,32 @@ namespace MonoGame.Tests.ContentPipeline
         }
 
         [Test]
+        public void BitmapCompress_Atc_Interpolated()
+        {
+            // validate that we can compress an atc interpolated texture
+            BitmapConvert(typeof(AtcInterpolatedBitmapContent), Color.Red, 64, 64);
+        }
+
+
+        [Test]
+        public void BitmapCompress_Etc1()
+        {
+            // validate that we can compress an atc interpolated texture
+            BitmapConvert(typeof(Etc1BitmapContent), Color.Red, 64, 64);
+        }
+
+        [Test]
+        public void BitmapCompress_Pvrtc()
+        {
+            // validate that we can compress a pvrtc rgb texture
+            BitmapConvert(typeof(PvrtcRgb4BitmapContent), Color.Red, 64, 64);
+
+            // validate that we can compress a pvrtc rgb texture
+            BitmapConvert(typeof(PvrtcRgba4BitmapContent), Color.Red, 64, 64);
+
+        }
+
+        [Test]
         public void BitmapCompress_Dxt1()
         {
             BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Red, 64, 64, 0);

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -176,6 +176,8 @@ namespace MonoGame.Tests.ContentPipeline
         [Test]
         public void BitmapCompressFullNoResize()
         {
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
+
 #if !XNA
             BitmapCompressFullNoResize<byte>(56);
 #endif
@@ -296,23 +298,19 @@ namespace MonoGame.Tests.ContentPipeline
             BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Red, 64, 64, 0);
             BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Green, 32, 34, 2);
             BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Blue, 8, 9, 0);
-
-            // BasisU does not support Bcn1 alpha punch-through, also known as Dxt1a. Therefor, the alpha channel is lost and always assumed to be opaque.
-            //  this is a test regression, and the following line _used_ to work.
-            // BitmapConvertAssert(typeof(Dxt1BitmapContent), new Color(0, 0, 0, 0), 16, 16, 0);
-            Assert.Catch<NotSupportedException>(() =>
-            {
-                BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Transparent, 64, 64, 0);
-            });
+            BitmapConvertAssert(typeof(Dxt1BitmapContent), Color.Transparent, 64, 64, 0);
         }
 
         [Test]
         public void BitmapCompress_Dxt3()
         {
-            Assert.Catch<NotSupportedException>(() =>
-            {
-                BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Gray, 64, 64, 0);
-            });
+            var Transparent = new Color(0, 0, 0, 0);
+            var Grey16Premult = new Color(16, 16, 16, 16);
+            BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Red, 64, 64, 0);
+            BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Green, 32, 34, 2);
+            BitmapConvertAssert(typeof(Dxt3BitmapContent), Color.Blue, 8, 9, 0);
+            BitmapConvertAssert(typeof(Dxt3BitmapContent), Transparent, 16, 16, 0);
+            BitmapConvertAssert(typeof(Dxt3BitmapContent), Grey16Premult, 16, 16, Grey16Premult, 1);
         }
 
         [Test]

--- a/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
+++ b/Tools/MonoGame.Tools.Tests/BitmapContentTests.cs
@@ -243,6 +243,7 @@ namespace MonoGame.Tests.ContentPipeline
         public void BitmapCompress_Atc_Interpolated()
         {
             // validate that we can compress an atc interpolated texture
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
             BitmapConvert(typeof(AtcInterpolatedBitmapContent), Color.Red, 64, 64);
         }
 
@@ -253,6 +254,14 @@ namespace MonoGame.Tests.ContentPipeline
             // validate that we can compress an atc interpolated texture
             using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
             BitmapConvert(typeof(Etc1BitmapContent), Color.Red, 64, 64);
+        }
+
+        [Test]
+        public void BitmapCompress_Etc2()
+        {
+            // validate that we can compress an atc interpolated texture
+            using var _ = ContextScopeFactory.BeginContext(new TestBitmapProcessorContext());
+            BitmapConvert(typeof(Etc2BitmapContent), Color.Red, 64, 64);
         }
 
         [Test]

--- a/Tools/MonoGame.Tools.Tests/TestBitmapProcessorContext.cs
+++ b/Tools/MonoGame.Tools.Tests/TestBitmapProcessorContext.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using Microsoft.Xna.Framework.Content.Pipeline;
+using MonoGame.Framework.Content;
+using MonoGame.Tests.ContentPipeline;
+
+namespace MonoGame.Tools.Tests
+{
+
+    public class TestBitmapProcessorContext : ContextScopeFactory.ContextScope
+    {
+        public override string IntermediateDirectory { get; }
+        public override ContentBuildLogger Logger { get; } = new TestContentBuildLogger();
+        public override ContentIdentity SourceIdentity { get; }
+
+        public TestBitmapProcessorContext()
+        {
+            var id = Guid.NewGuid().ToString();
+            SourceIdentity = new ContentIdentity(id);
+            IntermediateDirectory = Path.Combine("test", id);
+            Directory.CreateDirectory(IntermediateDirectory);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            // clean up directory
+            Directory.Delete(IntermediateDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
This is meant to be public for transparency, but I'm not ready to open it to the Monogame repo yet. 

As of Aug 15th, here is what I think I have left to do...
- [ ] formalize `basisu` distribution with monogame
- [x] find a better way to save an image file before it gets input to `basisu` CLI. Maybe there is even a way to pipe the input
- [x] formalize ATC
- [x] formalize ETC 
- [x] formalize Pvrtc
- [x] figure out what to do about DXT1a not being supported by `basisu`. 
- [x] figure out what to do about DXT3 not being supported by `basisu`
- [x] write unit tests for other formats if possible
- [x] figure out how to log possible errors or warnings, or commit to _not_ doing this
- [x] add support for ETC2 and ATSC
- [ ] test